### PR TITLE
feat: 회원가입 등록, 닉네임 중복 확인 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,8 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/WearWeather/wear/global/common/BaseTimeEntity.java
+++ b/src/main/java/com/WearWeather/wear/global/common/BaseTimeEntity.java
@@ -1,0 +1,23 @@
+package com.WearWeather.wear.global.common;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners({AuditingEntityListener.class})
+public class BaseTimeEntity {
+
+    @CreatedDate
+    private LocalDateTime createAt;
+
+    @LastModifiedDate
+    private LocalDateTime modifiedAt;
+
+}

--- a/src/main/java/com/WearWeather/wear/global/common/ResponseMessage.java
+++ b/src/main/java/com/WearWeather/wear/global/common/ResponseMessage.java
@@ -1,0 +1,6 @@
+package com.WearWeather.wear.global.common;
+
+public class ResponseMessage {
+    public static final String NICKNAME_AVAILABLE = "닉네임 사용 가능합니다.";
+
+}

--- a/src/main/java/com/WearWeather/wear/global/common/dto/ResponseCommonDTO.java
+++ b/src/main/java/com/WearWeather/wear/global/common/dto/ResponseCommonDTO.java
@@ -1,0 +1,15 @@
+package com.WearWeather.wear.global.common.dto;
+
+import com.WearWeather.wear.user.entity.User;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public class ResponseCommonDTO {
+
+    private final boolean success;
+    private final String message;
+
+}

--- a/src/main/java/com/WearWeather/wear/global/exception/CustomException.java
+++ b/src/main/java/com/WearWeather/wear/global/exception/CustomException.java
@@ -1,0 +1,19 @@
+package com.WearWeather.wear.global.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class CustomException extends RuntimeException{
+
+    private final HttpStatus httpStatus;
+    private final ErrorCode errorCode;
+    private final String errorMessage;
+
+    public CustomException(ErrorCode errorCode){
+
+        this.errorCode = errorCode;
+        this.errorMessage = errorCode.getMessage();
+        this.httpStatus = errorCode.getHttpStatus();
+    }
+}

--- a/src/main/java/com/WearWeather/wear/global/exception/ErrorCode.java
+++ b/src/main/java/com/WearWeather/wear/global/exception/ErrorCode.java
@@ -1,0 +1,32 @@
+package com.WearWeather.wear.global.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+
+@Getter
+public enum ErrorCode {
+
+    //Auth
+    EMAIL_IS_NULL_EXCEPTION(BAD_REQUEST, "이메일 값이 존재하지않습니다."),
+    EMAIL_INVALID_EXCEPTION(BAD_REQUEST,"유효하지 않은 이메일 값 입니다."),
+    PASSWORD_IS_NULL_EXCEPTION(BAD_REQUEST,"비밀번호 값이 존재하지않습니다."),
+    PASSWORD_INVALID_EXCEPTION(BAD_REQUEST,"유효하지 않은 비밀번호 값 입니다."),
+    NAME_IS_NULL_EXCEPTION(BAD_REQUEST,"이름 값이 존재하지않습니다."),
+    NICKNAME_IS_NULL_EXCEPTION(BAD_REQUEST,"닉네임 값이 존재하지않습니다."),
+    NICKNAME_INVALID_EXCEPTION(BAD_REQUEST,"유효하지 않은 닉네임 값 입니다."),
+
+    NICKNAME_ALREADY_EXIST(BAD_REQUEST, "닉네임이 중복되었습니다."),
+    NOT_EXIST_EMAIL(BAD_REQUEST, "일치하는 이메일이 없습니다."),
+    NOT_EXIST_USER(BAD_REQUEST, "일치하는 계정이 없습니다.")
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    ErrorCode(HttpStatus httpStatus, String message){
+        this.httpStatus = httpStatus;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/WearWeather/wear/user/controller/UserController.java
+++ b/src/main/java/com/WearWeather/wear/user/controller/UserController.java
@@ -1,0 +1,36 @@
+package com.WearWeather.wear.user.controller;
+
+import com.WearWeather.wear.global.common.ResponseMessage;
+import com.WearWeather.wear.global.common.dto.ResponseCommonDTO;
+import com.WearWeather.wear.user.dto.RequestEmailCheckDTO;
+import com.WearWeather.wear.user.dto.RequestRegisterUserDTO;
+import com.WearWeather.wear.user.dto.ResponseDuplicateCheckDTO;
+import com.WearWeather.wear.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@RequestMapping("/api/v1/users")
+@Validated
+@RestController
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    @PostMapping("/register")
+    public ResponseEntity<ResponseCommonDTO> signup(@Validated @RequestBody RequestRegisterUserDTO registerUserDTO){
+
+        userService.registerUser(registerUserDTO);
+        return ResponseEntity.ok(new ResponseCommonDTO(true, "User registered successfully."));
+    }
+
+    @GetMapping("/nickname-check/{nickname}")
+    public ResponseEntity<ResponseDuplicateCheckDTO> checkDuplicateNickname(@PathVariable("nickname") String nickname){
+
+        userService.checkDuplicateNickname(nickname);
+        return ResponseEntity.ok(new ResponseDuplicateCheckDTO(true, ResponseMessage.NICKNAME_AVAILABLE));
+    }
+
+}

--- a/src/main/java/com/WearWeather/wear/user/dto/RequestEmailCheckDTO.java
+++ b/src/main/java/com/WearWeather/wear/user/dto/RequestEmailCheckDTO.java
@@ -1,0 +1,15 @@
+package com.WearWeather.wear.user.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public class RequestEmailCheckDTO {
+
+    @NotBlank(message = "이메일은 필수입니다.")
+    @Email(message = "올바르지 않은 이메일 형식입니다.")
+    private final String email;
+}

--- a/src/main/java/com/WearWeather/wear/user/dto/RequestRegisterUserDTO.java
+++ b/src/main/java/com/WearWeather/wear/user/dto/RequestRegisterUserDTO.java
@@ -1,6 +1,7 @@
 package com.WearWeather.wear.user.dto;
 
 import com.WearWeather.wear.user.entity.User;
+import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
@@ -24,6 +25,12 @@ public class RequestRegisterUserDTO {
     private final String nickname;
 
     private final boolean isSocial;
+
+    @AssertTrue(message = "이메일 인증은 필수입니다.")
+    private final boolean checkEmail;
+
+    @AssertTrue(message = "닉네임 중복 확인은 필수입니다.")
+    private final boolean checkNickname;
 
     public User toEntity(){
         return User.builder()

--- a/src/main/java/com/WearWeather/wear/user/dto/RequestRegisterUserDTO.java
+++ b/src/main/java/com/WearWeather/wear/user/dto/RequestRegisterUserDTO.java
@@ -1,0 +1,38 @@
+package com.WearWeather.wear.user.dto;
+
+import com.WearWeather.wear.user.entity.User;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public class RequestRegisterUserDTO {
+
+    @NotBlank(message = "이메일은 필수입니다.")
+    @Email(message = "올바르지 않은 이메일 형식입니다.")
+    private final String email;
+
+    @NotBlank(message = "비밀번호는 필수입니다.")
+    private final String password;
+
+    @NotBlank(message = "이름은 필수입니다.")
+    private final String name;
+
+    @NotBlank(message = "닉네임은 필수입니다.")
+    private final String nickname;
+
+    private final boolean isSocial;
+
+    public User toEntity(){
+        return User.builder()
+                .email(email)
+                .password(password)
+                .name(name)
+                .nickname(nickname)
+                .isSocial(isSocial)
+                .role("USER")
+                .build();
+    }
+}

--- a/src/main/java/com/WearWeather/wear/user/dto/ResponseDuplicateCheckDTO.java
+++ b/src/main/java/com/WearWeather/wear/user/dto/ResponseDuplicateCheckDTO.java
@@ -1,0 +1,13 @@
+package com.WearWeather.wear.user.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public class ResponseDuplicateCheckDTO {
+
+    private final boolean isAvailable;
+    private final String message;
+
+}

--- a/src/main/java/com/WearWeather/wear/user/entity/User.java
+++ b/src/main/java/com/WearWeather/wear/user/entity/User.java
@@ -1,0 +1,127 @@
+package com.WearWeather.wear.user.entity;
+
+import com.WearWeather.wear.global.common.BaseTimeEntity;
+import com.WearWeather.wear.global.exception.ErrorCode;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.io.Serializable;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Getter
+@Entity
+public class User extends BaseTimeEntity implements Serializable {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long userId;
+
+    @Column(nullable = false)
+    private String email;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private String nickname;
+
+    @Column(nullable = false)
+    private boolean isSocial;
+
+    @Column(nullable = false)
+    private String role;
+
+    @Transient
+    public static final String EMAIL_REG = "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$\n";
+    @Transient
+    public static final String PASSWORD_REG = "^(?=.*[A-Za-z])(?=.*\\d|.*[!@#$%^&*])[A-Za-z\\d!@#$%^&*]{8,10}$|^(?=.*[!@#$%^&*])(?=.*\\d)[A-Za-z\\d!@#$%^&*]{8,10}$\n";
+    @Transient
+    public static final String NICKNAME_REG = "^[가-힣a-zA-Z]{1,10}$";
+
+
+    public User(String email, String password, String name, String nickname, boolean isSocial, String role){
+        validation(email, password, name, nickname);
+        this.email = email;
+        this.password = password;
+        this.name = name;
+        this.nickname = nickname;
+        this.isSocial = isSocial;
+        this.role = role;
+    }
+    public void validation(String email, String password, String name, String nickname){
+        isEmailNull(email);
+        checkEmailRegex(email);
+
+        isPasswordNull(password);
+        checkPasswordRegex(password);
+
+        isNameNull(name);
+
+        isNickNameNull(nickname);
+        checkNickNameRegex(nickname);
+    }
+
+    public void isEmailNull(String email){
+        if(email == null){
+            throw new IllegalArgumentException(ErrorCode.EMAIL_IS_NULL_EXCEPTION.getMessage());
+        }
+    }
+
+    public void checkEmailRegex(String email){
+        if(!email.matches(EMAIL_REG)){
+            throw new IllegalArgumentException(ErrorCode.EMAIL_INVALID_EXCEPTION.getMessage());
+        }
+    }
+
+    public void isPasswordNull(String password){
+        if(password == null){
+            throw new IllegalArgumentException(ErrorCode.PASSWORD_IS_NULL_EXCEPTION.getMessage());
+        }
+    }
+
+    public void checkPasswordRegex(String password){
+        if(!password.matches(PASSWORD_REG)){
+            throw new IllegalArgumentException(ErrorCode.PASSWORD_INVALID_EXCEPTION.getMessage());
+        }
+    }
+
+    public void isNameNull(String name){
+        if(name == null){
+            throw new IllegalArgumentException(ErrorCode.NAME_IS_NULL_EXCEPTION.getMessage());
+        }
+    }
+
+    public void isNickNameNull(String nickname){
+        if(nickname == null){
+            throw new IllegalArgumentException(ErrorCode.NICKNAME_IS_NULL_EXCEPTION.getMessage());
+        }
+    }
+
+    public void checkNickNameRegex(String nickname){
+        if(!nickname.matches(NICKNAME_REG)){
+            throw new IllegalArgumentException(ErrorCode.NICKNAME_INVALID_EXCEPTION.getMessage());
+        }
+    }
+
+    public void isRegularLogin(){
+        this.isSocial = false;
+    }
+
+    public void isSocialLogin(){
+        this.isSocial = true;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        User user = (User) o;
+        return email.equals(user.email)
+                && name.equals(user.name);
+    }
+}

--- a/src/main/java/com/WearWeather/wear/user/repository/UserRepository.java
+++ b/src/main/java/com/WearWeather/wear/user/repository/UserRepository.java
@@ -1,0 +1,12 @@
+package com.WearWeather.wear.user.repository;
+
+import com.WearWeather.wear.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByNickname(String nickname);
+
+}

--- a/src/main/java/com/WearWeather/wear/user/service/UserService.java
+++ b/src/main/java/com/WearWeather/wear/user/service/UserService.java
@@ -1,0 +1,46 @@
+package com.WearWeather.wear.user.service;
+
+import com.WearWeather.wear.global.exception.CustomException;
+import com.WearWeather.wear.user.dto.RequestRegisterUserDTO;
+import com.WearWeather.wear.user.dto.ResponseDuplicateCheckDTO;
+import com.WearWeather.wear.user.entity.User;
+import com.WearWeather.wear.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.WearWeather.wear.global.exception.ErrorCode.NICKNAME_ALREADY_EXIST;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    @Transactional
+    public void registerUser(RequestRegisterUserDTO requestRegisterUserDTO){
+
+        User user = requestRegisterUserDTO.toEntity();
+
+        if(requestRegisterUserDTO.isSocial()){
+            user.isSocialLogin();
+        }
+
+        if(!requestRegisterUserDTO.isSocial()){
+            user.isRegularLogin();
+        }
+
+        userRepository.save(user);
+    }
+
+    public void checkDuplicateNickname(String nickname){
+
+        boolean nicknameExist = userRepository.findByNickname(nickname).isPresent();
+
+        if(nicknameExist){
+            throw new CustomException(NICKNAME_ALREADY_EXIST);
+        }
+    }
+
+}


### PR DESCRIPTION
1. 회원가입 등록 시 닉네임 중복 확인 여부/ 이메일 인증 결과도 함께 데이터를 전달해야하지않을까요?
2. 이메일 인증할 때 중복 검사도 동시에 이루어져야하겠죠?