### PR TITLE
로그인, 로그아웃, 재발급 API 구현 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,39 +1,54 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.3.1'
-	id 'io.spring.dependency-management' version '1.1.5'
+    id 'java'
+    id 'org.springframework.boot' version '3.3.1'
+    id 'io.spring.dependency-management' version '1.1.5'
 }
 
 group = 'com.WearWeather'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(17)
-	}
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	compileOnly 'org.projectlombok:lombok'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.springframework.security:spring-security-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'it.ozimov:embedded-redis:0.7.2'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'org.springdoc:springdoc-openapi-ui:1.6.9'
+
+    runtimeOnly("com.h2database:h2")
+    implementation("org.springframework.boot:spring-boot-devtools")
+
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    testImplementation 'org.mockito:mockito-junit-jupiter:5.2.0'
+    testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.8.1'
+
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }

--- a/src/main/java/com/WearWeather/wear/auth/controller/AuthController.java
+++ b/src/main/java/com/WearWeather/wear/auth/controller/AuthController.java
@@ -2,6 +2,7 @@ package com.WearWeather.wear.auth.controller;
 
 import static com.WearWeather.wear.global.jwt.JwtFilter.AUTHORIZATION_HEADER;
 
+import com.WearWeather.wear.auth.dto.TokenDto;
 import com.WearWeather.wear.auth.dto.request.LoginRequest;
 import com.WearWeather.wear.auth.dto.response.LoginResponse;
 import com.WearWeather.wear.auth.service.AuthService;
@@ -34,4 +35,11 @@ public class AuthController {
         authService.logout(userEmail, token);
         return new ResponseEntity<>(HttpStatus.OK);
     }
+
+    @PostMapping("/reissue")
+    public ResponseEntity<TokenDto> reissue(@RequestBody TokenDto tokenDto) {
+        TokenDto newToken = authService.reissue(tokenDto);
+        return new ResponseEntity<>(newToken, HttpStatus.OK);
+    }
+
 }

--- a/src/main/java/com/WearWeather/wear/auth/controller/AuthController.java
+++ b/src/main/java/com/WearWeather/wear/auth/controller/AuthController.java
@@ -1,0 +1,28 @@
+package com.WearWeather.wear.auth.controller;
+
+import com.WearWeather.wear.auth.dto.request.LoginRequest;
+import com.WearWeather.wear.auth.dto.response.LoginResponse;
+import com.WearWeather.wear.auth.service.AuthService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/auth")
+public class AuthController {
+    private final AuthService authService;
+
+    public AuthController(AuthService authService) {
+        this.authService = authService;
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<LoginResponse> login (@Valid @RequestBody LoginRequest request) {
+        return new ResponseEntity<>(authService.checkLogin(request), HttpStatus.OK);
+    }
+
+}

--- a/src/main/java/com/WearWeather/wear/auth/controller/AuthController.java
+++ b/src/main/java/com/WearWeather/wear/auth/controller/AuthController.java
@@ -1,5 +1,7 @@
 package com.WearWeather.wear.auth.controller;
 
+import static com.WearWeather.wear.global.jwt.JwtFilter.AUTHORIZATION_HEADER;
+
 import com.WearWeather.wear.auth.dto.request.LoginRequest;
 import com.WearWeather.wear.auth.dto.response.LoginResponse;
 import com.WearWeather.wear.auth.service.AuthService;
@@ -8,6 +10,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -25,4 +28,10 @@ public class AuthController {
         return new ResponseEntity<>(authService.checkLogin(request), HttpStatus.OK);
     }
 
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout(String userEmail, @RequestHeader(AUTHORIZATION_HEADER) String tokenHeader) {
+        String token = tokenHeader.replace("Bearer ", "");
+        authService.logout(userEmail, token);
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
 }

--- a/src/main/java/com/WearWeather/wear/auth/dto/AuthorityDto.java
+++ b/src/main/java/com/WearWeather/wear/auth/dto/AuthorityDto.java
@@ -1,0 +1,16 @@
+package com.WearWeather.wear.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class AuthorityDto {
+   private String authorityName;
+}

--- a/src/main/java/com/WearWeather/wear/auth/dto/TokenDto.java
+++ b/src/main/java/com/WearWeather/wear/auth/dto/TokenDto.java
@@ -1,0 +1,20 @@
+package com.WearWeather.wear.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+public class TokenDto {
+
+    private String accessToken;
+    private String refreshToken;
+}

--- a/src/main/java/com/WearWeather/wear/auth/dto/request/LoginRequest.java
+++ b/src/main/java/com/WearWeather/wear/auth/dto/request/LoginRequest.java
@@ -1,0 +1,31 @@
+package com.WearWeather.wear.auth.dto.request;
+
+import com.WearWeather.wear.user.entity.User;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class LoginRequest {
+
+    @NotNull
+    @Size(min = 3, max = 50)
+    private String email;
+
+    @NotNull
+    @Size(min = 3, max = 100)
+    private String password;
+
+    public User toEntity() {
+        return User.builder()
+            .email(email)
+            .password(password)
+            .build();
+    }
+}

--- a/src/main/java/com/WearWeather/wear/auth/dto/request/LoginRequest.java
+++ b/src/main/java/com/WearWeather/wear/auth/dto/request/LoginRequest.java
@@ -1,6 +1,7 @@
 package com.WearWeather.wear.auth.dto.request;
 
 import com.WearWeather.wear.user.entity.User;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
@@ -14,11 +15,11 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class LoginRequest {
 
-    @NotNull
+    @NotBlank
     @Size(min = 3, max = 50)
     private String email;
 
-    @NotNull
+    @NotBlank
     @Size(min = 3, max = 100)
     private String password;
 

--- a/src/main/java/com/WearWeather/wear/auth/dto/response/LoginResponse.java
+++ b/src/main/java/com/WearWeather/wear/auth/dto/response/LoginResponse.java
@@ -18,7 +18,6 @@ public class LoginResponse {
         private String username;
         private String nickName;
         private boolean isSocial;
-        private boolean activated;
         private Set<Authority> authorities;
         private String accessToken;
         private String refreshToken;
@@ -30,8 +29,7 @@ public class LoginResponse {
                 .username(user.getName())
                 .nickName(user.getNickname())
                 .isSocial(user.isSocial())
-                .activated(user.isActivated())
-                .authorities(user.getAuthorities())  // 권한 정보 포함
+                .authorities(user.getAuthorities())
                 .accessToken(atk)
                 .refreshToken(rtk)
                 .build();

--- a/src/main/java/com/WearWeather/wear/auth/dto/response/LoginResponse.java
+++ b/src/main/java/com/WearWeather/wear/auth/dto/response/LoginResponse.java
@@ -1,0 +1,39 @@
+package com.WearWeather.wear.auth.dto.response;
+
+import com.WearWeather.wear.auth.entity.Authority;
+import com.WearWeather.wear.user.entity.User;
+import java.util.Set;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class LoginResponse {
+        private Long userId;
+        private String email;
+        private String username;
+        private String nickName;
+        private boolean isSocial;
+        private boolean activated;
+        private Set<Authority> authorities;
+        private String accessToken;
+        private String refreshToken;
+
+        public static LoginResponse of (User user, String atk, String rtk) {
+            return LoginResponse.builder()
+                .userId(user.getUserId())
+                .email(user.getEmail())
+                .username(user.getName())
+                .nickName(user.getNickname())
+                .isSocial(user.isSocial())
+                .activated(user.isActivated())
+                .authorities(user.getAuthorities())  // 권한 정보 포함
+                .accessToken(atk)
+                .refreshToken(rtk)
+                .build();
+        }
+    }

--- a/src/main/java/com/WearWeather/wear/auth/entity/Authority.java
+++ b/src/main/java/com/WearWeather/wear/auth/entity/Authority.java
@@ -1,0 +1,25 @@
+package com.WearWeather.wear.auth.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "authority")
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class Authority {
+
+   @Id
+   @Column(name = "authority_name", length = 50)
+   private String authorityName;
+}

--- a/src/main/java/com/WearWeather/wear/auth/repository/AuthorityRepository.java
+++ b/src/main/java/com/WearWeather/wear/auth/repository/AuthorityRepository.java
@@ -1,0 +1,7 @@
+package com.WearWeather.wear.auth.repository;
+
+import com.WearWeather.wear.auth.entity.Authority;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AuthorityRepository extends JpaRepository<Authority, String> {
+}

--- a/src/main/java/com/WearWeather/wear/auth/service/AuthService.java
+++ b/src/main/java/com/WearWeather/wear/auth/service/AuthService.java
@@ -41,6 +41,17 @@ public class AuthService {
         return LoginResponse.of(user, accessToken, refreshToken);
     }
 
+    public void logout(String email, String accessToken) {
+        validateExistedUserEmail(email);
+
+        Long accessTokenExpiration = tokenProvider.getExpiration(accessToken);
+        redisService.logoutFromRedis(email,accessToken, accessTokenExpiration);
+    }
+    private void validateExistedUserEmail(String email) {
+        userRepository.findByEmail(email)
+            .orElseThrow(() -> new CustomException(ErrorCode.EMAIL_IS_NULL_EXCEPTION));
+    }
+
     private void validatePassword(String password, String encodePassword) {
         if (!passwordEncoder.matches(password, encodePassword)) {
             throw new CustomException(ErrorCode.PASSWORD_INVALID_EXCEPTION);

--- a/src/main/java/com/WearWeather/wear/auth/service/AuthService.java
+++ b/src/main/java/com/WearWeather/wear/auth/service/AuthService.java
@@ -1,0 +1,55 @@
+package com.WearWeather.wear.auth.service;
+
+import com.WearWeather.wear.global.exception.CustomException;
+import com.WearWeather.wear.global.exception.ErrorCode;
+import com.WearWeather.wear.global.jwt.TokenProvider;
+import com.WearWeather.wear.global.redis.RedisService;
+import com.WearWeather.wear.auth.dto.request.LoginRequest;
+import com.WearWeather.wear.auth.dto.response.LoginResponse;
+import com.WearWeather.wear.user.entity.User;
+import com.WearWeather.wear.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final AuthenticationManagerBuilder authenticationManagerBuilder;
+    private final TokenProvider tokenProvider;
+
+    public LoginResponse checkLogin(LoginRequest request) {
+        User user = userRepository.findOneWithAuthoritiesByEmail(request.getEmail())
+            .orElseThrow(() -> new CustomException(ErrorCode.EMAIL_IS_NULL_EXCEPTION));
+
+        validatePassword(request.getPassword(), user.getPassword());
+
+        Authentication authentication = getAuthentication(request.getEmail(), request.getPassword());
+        String accessToken = tokenProvider.createToken(authentication);
+        String refreshToken = tokenProvider.createRefreshToken(request.getEmail());
+
+        return LoginResponse.of(user, accessToken, refreshToken);
+    }
+
+    private void validatePassword(String password, String encodePassword) {
+        if (!passwordEncoder.matches(password, encodePassword)) {
+            throw new CustomException(ErrorCode.PASSWORD_INVALID_EXCEPTION);
+        }
+    }
+
+    private Authentication getAuthentication(String email, String password) {
+        UsernamePasswordAuthenticationToken authenticationToken =
+            new UsernamePasswordAuthenticationToken(email, password);
+        Authentication authentication = authenticationManagerBuilder.getObject().authenticate(authenticationToken);
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        return authentication;
+    }
+}

--- a/src/main/java/com/WearWeather/wear/auth/service/AuthService.java
+++ b/src/main/java/com/WearWeather/wear/auth/service/AuthService.java
@@ -24,6 +24,7 @@ public class AuthService {
     private final PasswordEncoder passwordEncoder;
     private final AuthenticationManagerBuilder authenticationManagerBuilder;
     private final TokenProvider tokenProvider;
+    private final RedisService  redisService;
 
     public LoginResponse checkLogin(LoginRequest request) {
         User user = userRepository.findOneWithAuthoritiesByEmail(request.getEmail())
@@ -34,6 +35,8 @@ public class AuthService {
         Authentication authentication = getAuthentication(request.getEmail(), request.getPassword());
         String accessToken = tokenProvider.createToken(authentication);
         String refreshToken = tokenProvider.createRefreshToken(request.getEmail());
+
+        redisService.setValues(request.getEmail(), refreshToken);
 
         return LoginResponse.of(user, accessToken, refreshToken);
     }

--- a/src/main/java/com/WearWeather/wear/global/config/CorsConfig.java
+++ b/src/main/java/com/WearWeather/wear/global/config/CorsConfig.java
@@ -1,0 +1,24 @@
+package com.WearWeather.wear.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.filter.CorsFilter;
+
+@Configuration
+public class CorsConfig {
+
+    @Bean
+    public CorsFilter corsFilter() {
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowCredentials(true);
+        config.addAllowedOriginPattern("*");
+        config.addAllowedHeader("*");
+        config.addAllowedMethod("*");
+
+        source.registerCorsConfiguration("/api/**", config);
+        return new CorsFilter(source);
+    }
+}

--- a/src/main/java/com/WearWeather/wear/global/config/JwtSecurityConfig.java
+++ b/src/main/java/com/WearWeather/wear/global/config/JwtSecurityConfig.java
@@ -1,0 +1,25 @@
+package com.WearWeather.wear.global.config;
+
+import com.WearWeather.wear.global.jwt.JwtFilter;
+import com.WearWeather.wear.global.jwt.TokenProvider;
+import org.springframework.security.config.annotation.SecurityConfigurerAdapter;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.DefaultSecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+public class JwtSecurityConfig extends SecurityConfigurerAdapter<DefaultSecurityFilterChain, HttpSecurity> {
+
+    private final TokenProvider tokenProvider;
+
+    public JwtSecurityConfig(TokenProvider tokenProvider) {
+        this.tokenProvider = tokenProvider;
+    }
+
+    @Override
+    public void configure(HttpSecurity http) {
+        http.addFilterBefore(
+            new JwtFilter(tokenProvider),
+            UsernamePasswordAuthenticationFilter.class
+        );
+    }
+}

--- a/src/main/java/com/WearWeather/wear/global/config/RedisConfig.java
+++ b/src/main/java/com/WearWeather/wear/global/config/RedisConfig.java
@@ -1,0 +1,36 @@
+package com.WearWeather.wear.global.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@RequiredArgsConstructor
+@Configuration
+@EnableRedisRepositories
+public class RedisConfig {
+
+    private final RedisProperties redisProperties;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(redisProperties.getHost(), redisProperties.getPort());
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+
+        return redisTemplate;
+    }
+}

--- a/src/main/java/com/WearWeather/wear/global/config/SecurityConfig.java
+++ b/src/main/java/com/WearWeather/wear/global/config/SecurityConfig.java
@@ -1,0 +1,78 @@
+package com.WearWeather.wear.global.config;
+
+
+import com.WearWeather.wear.global.jwt.handler.JwtAccessDeniedHandler;
+import com.WearWeather.wear.global.jwt.handler.JwtAuthenticationEntryPoint;
+import com.WearWeather.wear.global.jwt.TokenProvider;
+import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.filter.CorsFilter;
+
+@EnableWebSecurity
+@EnableMethodSecurity
+@Configuration
+public class SecurityConfig {
+
+    private final TokenProvider tokenProvider;
+    private final CorsFilter corsFilter;
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+    private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
+
+    public SecurityConfig(
+        TokenProvider tokenProvider,
+        CorsFilter corsFilter,
+        JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint,
+        JwtAccessDeniedHandler jwtAccessDeniedHandler
+    ) {
+        this.tokenProvider = tokenProvider;
+        this.corsFilter = corsFilter;
+        this.jwtAuthenticationEntryPoint = jwtAuthenticationEntryPoint;
+        this.jwtAccessDeniedHandler = jwtAccessDeniedHandler;
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+            .csrf(AbstractHttpConfigurer::disable)
+
+            .addFilterBefore(corsFilter, UsernamePasswordAuthenticationFilter.class)
+            .exceptionHandling(exceptionHandling -> exceptionHandling
+                .accessDeniedHandler(jwtAccessDeniedHandler)
+                .authenticationEntryPoint(jwtAuthenticationEntryPoint)
+            )
+
+            .authorizeHttpRequests(authorizeHttpRequests -> authorizeHttpRequests
+                .requestMatchers("/auth/login", "/auth/reissue", "/api/user/signup", "/").permitAll()
+                .requestMatchers(PathRequest.toH2Console()).permitAll()
+                .anyRequest().authenticated()
+            )
+
+            .sessionManagement(sessionManagement ->
+                sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+            )
+
+            .headers(headers ->
+                headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::sameOrigin)
+            )
+
+            .with(new JwtSecurityConfig(tokenProvider), customizer -> {
+            });
+        return http.build();
+    }
+}

--- a/src/main/java/com/WearWeather/wear/global/exception/CustomException.java
+++ b/src/main/java/com/WearWeather/wear/global/exception/CustomException.java
@@ -1,0 +1,19 @@
+package com.WearWeather.wear.global.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class CustomException extends RuntimeException{
+
+    private final HttpStatus httpStatus;
+    private final ErrorCode errorCode;
+    private final String errorMessage;
+
+    public CustomException(ErrorCode errorCode){
+
+        this.errorCode = errorCode;
+        this.errorMessage = errorCode.getMessage();
+        this.httpStatus = errorCode.getHttpStatus();
+    }
+}

--- a/src/main/java/com/WearWeather/wear/global/exception/ErrorCode.java
+++ b/src/main/java/com/WearWeather/wear/global/exception/ErrorCode.java
@@ -1,8 +1,10 @@
 package com.WearWeather.wear.global.exception;
 
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 import lombok.Getter;
+import org.hibernate.annotations.NotFound;
 import org.springframework.http.HttpStatus;
 
 @Getter
@@ -24,7 +26,11 @@ public enum ErrorCode {
     NOT_EXIST_USER(BAD_REQUEST, "일치하는 계정이 없습니다."),
     NO_SUCH_ALGORITHM(BAD_REQUEST, "해당 알고리즘이 존재하지 않습니다."),
 
-    UNABLE_TO_SEND_EMAIL(BAD_REQUEST,"해당 이메일로 코드를 발송하지 못했습니다.")
+    UNABLE_TO_SEND_EMAIL(BAD_REQUEST,"해당 이메일로 코드를 발송하지 못했습니다."),
+
+    INVALID_REFRESH_TOKEN(BAD_REQUEST,"리프레시 토큰 값이 일치하지 않습니다."),
+
+    REDIS_VALUE_NOT_FOUND(NOT_FOUND,"Redis에 저장된 값을 찾을 수 없습니다.")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/WearWeather/wear/global/exception/ErrorCode.java
+++ b/src/main/java/com/WearWeather/wear/global/exception/ErrorCode.java
@@ -1,0 +1,37 @@
+package com.WearWeather.wear.global.exception;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum ErrorCode {
+
+    //Domain-user
+    EMAIL_IS_NULL_EXCEPTION(BAD_REQUEST, "이메일 값이 존재하지않습니다."),
+    EMAIL_INVALID_EXCEPTION(BAD_REQUEST,"유효하지 않은 이메일 값 입니다."),
+    PASSWORD_IS_NULL_EXCEPTION(BAD_REQUEST,"비밀번호 값이 존재하지않습니다."),
+    PASSWORD_INVALID_EXCEPTION(BAD_REQUEST,"유효하지 않은 비밀번호 값 입니다."),
+    NAME_IS_NULL_EXCEPTION(BAD_REQUEST,"이름 값이 존재하지않습니다."),
+    NICKNAME_IS_NULL_EXCEPTION(BAD_REQUEST,"닉네임 값이 존재하지않습니다."),
+    NICKNAME_INVALID_EXCEPTION(BAD_REQUEST,"유효하지 않은 닉네임 값 입니다."),
+
+    //User
+    NICKNAME_ALREADY_EXIST(BAD_REQUEST, "닉네임이 중복되었습니다."),
+    EMAIL_ALREADY_EXIST(BAD_REQUEST, "이메일이 중복되었습니다."),
+    NOT_EXIST_EMAIL(BAD_REQUEST, "일치하는 이메일이 없습니다."),
+    NOT_EXIST_USER(BAD_REQUEST, "일치하는 계정이 없습니다."),
+    NO_SUCH_ALGORITHM(BAD_REQUEST, "해당 알고리즘이 존재하지 않습니다."),
+
+    UNABLE_TO_SEND_EMAIL(BAD_REQUEST,"해당 이메일로 코드를 발송하지 못했습니다.")
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    ErrorCode(HttpStatus httpStatus, String message){
+        this.httpStatus = httpStatus;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/WearWeather/wear/global/jwt/CustomUserDetailsService.java
+++ b/src/main/java/com/WearWeather/wear/global/jwt/CustomUserDetailsService.java
@@ -1,0 +1,46 @@
+package com.WearWeather.wear.global.jwt;
+
+import com.WearWeather.wear.user.entity.User;
+import com.WearWeather.wear.user.repository.UserRepository;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component("userDetailsService")
+public class CustomUserDetailsService implements UserDetailsService {
+    private final UserRepository userRepository;
+
+    public CustomUserDetailsService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    @Transactional
+    public UserDetails loadUserByUsername(final String userEmail) {
+        return userRepository.findOneWithAuthoritiesByEmail(userEmail)
+            .map(user -> createUser(userEmail, user))
+            .orElseThrow(() -> new UsernameNotFoundException(userEmail + " -> 데이터베이스에서 찾을 수 없습니다."));
+    }
+
+    private org.springframework.security.core.userdetails.User createUser(String userEmail, User user) {
+        if (!user.isActivated()) {
+            throw new RuntimeException(userEmail + " -> 활성화되어 있지 않습니다.");
+        }
+
+        // 유저의 권한 정보들
+        List<GrantedAuthority> grantedAuthorities = user.getAuthorities().stream()
+            .map(authority -> new SimpleGrantedAuthority(authority.getAuthorityName()))
+            .collect(Collectors.toList());
+
+        // 유저 네임, 패스워드, 권한정보를 User 객체로 리턴
+        return new org.springframework.security.core.userdetails.User(user.getEmail(),
+            user.getPassword(),
+            grantedAuthorities);
+    }
+}

--- a/src/main/java/com/WearWeather/wear/global/jwt/CustomUserDetailsService.java
+++ b/src/main/java/com/WearWeather/wear/global/jwt/CustomUserDetailsService.java
@@ -29,9 +29,6 @@ public class CustomUserDetailsService implements UserDetailsService {
     }
 
     private org.springframework.security.core.userdetails.User createUser(String userEmail, User user) {
-        if (!user.isActivated()) {
-            throw new RuntimeException(userEmail + " -> 활성화되어 있지 않습니다.");
-        }
 
         // 유저의 권한 정보들
         List<GrantedAuthority> grantedAuthorities = user.getAuthorities().stream()

--- a/src/main/java/com/WearWeather/wear/global/jwt/JwtFilter.java
+++ b/src/main/java/com/WearWeather/wear/global/jwt/JwtFilter.java
@@ -1,0 +1,58 @@
+package com.WearWeather.wear.global.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import java.io.IOException;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.GenericFilterBean;
+
+@Slf4j
+@RequiredArgsConstructor
+public class JwtFilter extends GenericFilterBean {
+
+    private static final Logger logger = LoggerFactory.getLogger(JwtFilter.class);
+    public static final String AUTHORIZATION_HEADER = "Authorization";
+    private TokenProvider tokenProvider;
+
+    public JwtFilter(TokenProvider tokenProvider) {
+        this.tokenProvider = tokenProvider;
+    }
+
+    // 토큰의 인증정보(ID,권한 정보 등) 를 SecurityContext에 저장
+    @Override
+    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain) throws IOException, ServletException {
+        HttpServletRequest httpServletRequest = (HttpServletRequest) servletRequest;
+        String jwt = resolveToken(httpServletRequest);
+        String requestURI = httpServletRequest.getRequestURI();
+
+        if (StringUtils.hasText(jwt) && tokenProvider.validateToken(jwt)) {
+            Authentication authentication = tokenProvider.getAuthentication(jwt);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+            logger.debug("Security Context에 '{}' 인증 정보를 저장했습니다, uri: {}", authentication.getName(), requestURI);
+        } else {
+            logger.debug("유효한 JWT 토큰이 없습니다, uri: {}", requestURI);
+        }
+
+        filterChain.doFilter(servletRequest, servletResponse);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
+
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/com/WearWeather/wear/global/jwt/TokenProvider.java
+++ b/src/main/java/com/WearWeather/wear/global/jwt/TokenProvider.java
@@ -33,7 +33,6 @@ public class TokenProvider implements InitializingBean {
     private final Logger logger = LoggerFactory.getLogger(TokenProvider.class);
     private static final String AUTHORITIES_KEY = "auth";
     private final String secret;
-    private final String auth;
     private final long tokenValidityInMilliseconds;
     private final long refreshTokenValidityInMilliseconds;
     private Key key;
@@ -41,10 +40,8 @@ public class TokenProvider implements InitializingBean {
     public TokenProvider(
             @Value("${jwt.secret}") String secret,
             @Value("${jwt.token-validity-in-seconds}") long tokenValidityInSeconds,
-            @Value("${jwt.refresh-token-validity-in-seconds}") long refreshTokenValidityInSeconds,
-            @Value("${jwt.auth.secret}") String auth) {
+            @Value("${jwt.refresh-token-validity-in-seconds}") long refreshTokenValidityInSeconds) {
         this.secret = secret;
-        this.auth = auth;
         this.tokenValidityInMilliseconds = tokenValidityInSeconds * 1000;
         this.refreshTokenValidityInMilliseconds = refreshTokenValidityInSeconds * 1000;;
     }

--- a/src/main/java/com/WearWeather/wear/global/jwt/TokenProvider.java
+++ b/src/main/java/com/WearWeather/wear/global/jwt/TokenProvider.java
@@ -1,0 +1,135 @@
+package com.WearWeather.wear.global.jwt;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import java.security.Key;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+public class TokenProvider implements InitializingBean {
+
+    private final Logger logger = LoggerFactory.getLogger(TokenProvider.class);
+    private static final String AUTHORITIES_KEY = "auth";
+    private final String secret;
+    private final String auth;
+    private final long tokenValidityInMilliseconds;
+    private final long refreshTokenValidityInMilliseconds;
+    private Key key;
+
+    public TokenProvider(
+            @Value("${jwt.secret}") String secret,
+            @Value("${jwt.token-validity-in-seconds}") long tokenValidityInSeconds,
+            @Value("${jwt.refresh-token-validity-in-seconds}") long refreshTokenValidityInSeconds,
+            @Value("${jwt.auth.secret}") String auth) {
+        this.secret = secret;
+        this.auth = auth;
+        this.tokenValidityInMilliseconds = tokenValidityInSeconds * 1000;
+        this.refreshTokenValidityInMilliseconds = refreshTokenValidityInSeconds * 1000;;
+    }
+
+    // application.yml에서 secret 값 가져와서 key에 저장
+    @Override
+    public void afterPropertiesSet() {
+        byte[] keyBytes = Decoders.BASE64.decode(secret);
+        this.key = Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+            return true;
+        } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
+            log.info("잘못된 JWT 서명입니다.");
+        } catch (ExpiredJwtException e) {
+            log.info("만료된 JWT 토큰입니다.");
+        } catch (UnsupportedJwtException e) {
+            log.info("지원되지 않는 JWT 토큰입니다.");
+        } catch (IllegalArgumentException e) {
+            log.info("JWT 토큰이 잘못되었습니다.");
+        }
+        return false;
+    }
+
+    public String createToken(Authentication authentication) {
+        String authorities = authentication.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .collect(Collectors.joining(","));
+
+        long now = (new Date()).getTime();
+        Date validity = new Date(now + this.tokenValidityInMilliseconds);
+
+        return Jwts.builder()
+                .setSubject(authentication.getName())
+                .claim(AUTHORITIES_KEY, authorities)
+                .setExpiration(validity)
+                .signWith(key, SignatureAlgorithm.HS512)
+                .compact();
+    }
+
+    public String createRefreshToken(String email) {
+        long now = (new Date()).getTime();
+        Date validity = new Date(now + this.refreshTokenValidityInMilliseconds);
+
+        String refreshToken = Jwts.builder()
+                .setSubject(email)
+                .setExpiration(validity)
+                .signWith(key, SignatureAlgorithm.HS512)
+                .compact();
+
+        return  refreshToken;
+    }
+
+    public Long getExpiration(String accessToken) {
+        // accessToken 남은 유효시간
+        Date expiration = Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(accessToken)
+                .getBody()
+                .getExpiration();// 현재 시간
+        Long now = new Date().getTime();
+
+        return (expiration.getTime() - now);
+    }
+
+    public Authentication getAuthentication(String token) {
+        Claims claims = Jwts
+                .parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+
+        Collection<? extends GrantedAuthority> authorities =
+                Arrays.stream(claims.get(AUTHORITIES_KEY).toString().split(","))
+                        .map(SimpleGrantedAuthority::new)
+                        .collect(Collectors.toList());
+
+        // UserDetails 객체를 만들어서 Authentication return
+        User principal = new User(claims.getSubject(), "", authorities);
+        return new UsernamePasswordAuthenticationToken(principal, token, authorities);
+    }
+
+}

--- a/src/main/java/com/WearWeather/wear/global/jwt/handler/JwtAccessDeniedHandler.java
+++ b/src/main/java/com/WearWeather/wear/global/jwt/handler/JwtAccessDeniedHandler.java
@@ -1,0 +1,18 @@
+package com.WearWeather.wear.global.jwt.handler;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException {
+
+        response.sendError(HttpServletResponse.SC_FORBIDDEN);
+    }
+}

--- a/src/main/java/com/WearWeather/wear/global/jwt/handler/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/WearWeather/wear/global/jwt/handler/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,24 @@
+package com.WearWeather.wear.global.jwt.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(HttpServletRequest request,
+                        HttpServletResponse response,
+                        AuthenticationException authException) throws IOException {
+        response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+    }
+}

--- a/src/main/java/com/WearWeather/wear/global/redis/RedisDao.java
+++ b/src/main/java/com/WearWeather/wear/global/redis/RedisDao.java
@@ -1,0 +1,44 @@
+package com.WearWeather.wear.global.redis;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RedisDao {
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public void setValues(String key, String data) {
+        ValueOperations<String, String> values = redisTemplate.opsForValue();
+        values.set(key, data);
+    }
+
+
+    public void setValuesList(String key, String data) {
+        redisTemplate.opsForList().rightPushAll(key, data);
+    }
+
+    public List<String> getValuesList(String key) {
+        Long len = redisTemplate.opsForList().size(key);
+        return len == 0 ? new ArrayList<>() : redisTemplate.opsForList().range(key, 0, len - 1);
+    }
+
+    public void setValues(String key, String data, Duration duration) {
+        ValueOperations<String, String> values = redisTemplate.opsForValue();
+        values.set(key, data, duration);
+    }
+
+    public String getValues(String key) {
+        ValueOperations<String, String> values = redisTemplate.opsForValue();
+        return values.get(key);
+    }
+
+    public void deleteValues(String key) {
+        redisTemplate.delete(key);
+    }
+}

--- a/src/main/java/com/WearWeather/wear/global/redis/RedisService.java
+++ b/src/main/java/com/WearWeather/wear/global/redis/RedisService.java
@@ -1,0 +1,52 @@
+package com.WearWeather.wear.global.redis;
+
+
+import static com.WearWeather.wear.global.exception.ErrorCode.REDIS_VALUE_NOT_FOUND;
+
+import com.WearWeather.wear.global.exception.CustomException;
+import java.time.Duration;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RedisService {
+
+    private final RedisDao redisDao;
+
+    public Boolean setValues(String key, String value) {
+        redisDao.setValues(key, value);
+        return true;
+    }
+
+    public String getValues(String key) {
+        String values = redisDao.getValues(key);
+
+        if (values.isBlank()) {
+            throw new CustomException(REDIS_VALUE_NOT_FOUND);
+        }
+
+        return values;
+    }
+
+    public Integer getValuesInteger(Long key) {
+        String values = redisDao.getValues(key.toString());
+
+        if (values.isBlank()) {
+            throw new CustomException(REDIS_VALUE_NOT_FOUND);
+        }
+
+        return Integer.valueOf(values);
+    }
+
+    public Boolean logoutFromRedis(String email, String accessToken, Long accessTokenExpiration) {
+        redisDao.deleteValues(email);
+        redisDao.setValues(accessToken, "BlackList" , Duration.ofMillis(accessTokenExpiration));
+        return true;
+    }
+
+
+
+
+
+}

--- a/src/main/java/com/WearWeather/wear/global/util/SecurityUtil.java
+++ b/src/main/java/com/WearWeather/wear/global/util/SecurityUtil.java
@@ -1,0 +1,34 @@
+package com.WearWeather.wear.global.util;
+
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+
+public class SecurityUtil {
+
+   private static final Logger logger = LoggerFactory.getLogger(SecurityUtil.class);
+
+   private SecurityUtil() {}
+
+   public static Optional<String> getCurrentUsername() {
+      final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+      if (authentication == null) {
+         logger.debug("Security Context에 인증 정보가 없습니다.");
+         return Optional.empty();
+      }
+
+      String username = null;
+      if (authentication.getPrincipal() instanceof UserDetails) {
+         UserDetails springSecurityUser = (UserDetails) authentication.getPrincipal();
+         username = springSecurityUser.getUsername();
+      } else if (authentication.getPrincipal() instanceof String) {
+         username = (String) authentication.getPrincipal();
+      }
+
+      return Optional.ofNullable(username);
+   }
+}

--- a/src/main/java/com/WearWeather/wear/user/entity/User.java
+++ b/src/main/java/com/WearWeather/wear/user/entity/User.java
@@ -1,0 +1,56 @@
+package com.WearWeather.wear.user.entity;
+
+import com.WearWeather.wear.auth.entity.Authority;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.Table;
+import java.util.Set;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "`user`")
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class User {
+
+   @Id
+   @Column(name = "user_id")
+   @GeneratedValue(strategy = GenerationType.IDENTITY)
+   private long userId;
+
+   @Column(name = "email", nullable = false)
+   private String email;
+
+   @Column(name = "password", length = 100, nullable = false)
+   private String password;
+
+   @Column(name = "name", length = 50, nullable = false)
+   private String name;
+
+   @Column(name = "nickname", length = 50, nullable = false)
+   private String nickname;
+
+   @Column(name = "is_social", nullable = false)
+   private boolean isSocial;
+
+   @Column(name = "activated")
+   private boolean activated;
+
+   @ManyToMany
+   @JoinTable(
+       name = "user_authority",
+       joinColumns = {@JoinColumn(name = "user_id", referencedColumnName = "user_id")},
+       inverseJoinColumns = {@JoinColumn(name = "authority_name", referencedColumnName = "authority_name")})
+   private Set<Authority> authorities;
+}

--- a/src/main/java/com/WearWeather/wear/user/entity/User.java
+++ b/src/main/java/com/WearWeather/wear/user/entity/User.java
@@ -44,9 +44,6 @@ public class User {
    @Column(name = "is_social", nullable = false)
    private boolean isSocial;
 
-   @Column(name = "activated")
-   private boolean activated;
-
    @ManyToMany
    @JoinTable(
        name = "user_authority",

--- a/src/main/java/com/WearWeather/wear/user/repository/UserRepository.java
+++ b/src/main/java/com/WearWeather/wear/user/repository/UserRepository.java
@@ -1,0 +1,15 @@
+package com.WearWeather.wear.user.repository;
+
+import com.WearWeather.wear.user.entity.User;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+   @EntityGraph(attributePaths = "authorities")
+   Optional<User> findOneWithAuthoritiesByEmail(String email);
+
+   Optional<User> findByEmail(String email);
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,26 @@
 spring.application.name=wear
+
+# Spring H2 console
+spring.h2.console.enabled=true
+
+# Spring Datasource
+spring.datasource.url=jdbc:h2:mem:testdb;DATABASE_TO_UPPER=FALSE;
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.username=geonhui
+spring.datasource.password=
+
+# Spring JPA
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.properties.hibernate.format_sql=true
+spring.jpa.properties.hibernate.show_sql=true
+spring.jpa.defer-datasource-initialization=true
+
+# JWT
+jwt.header=Authorization
+jwt.secret=21ffcf7f622f11d797a0328917e3810f151f5d3cef2648359c677fed80ba56b094345d89ada2e8a4f570b998f3125b60e5c6c7e748e2cf3c6bb8070f3e44acff
+jwt.token-validity-in-seconds=86400
+jwt.refresh-token-validity-in-seconds=86400
+
+
+logging.level.me.silvernine=DEBUG

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -22,5 +22,9 @@ jwt.secret=21ffcf7f622f11d797a0328917e3810f151f5d3cef2648359c677fed80ba56b094345
 jwt.token-validity-in-seconds=86400
 jwt.refresh-token-validity-in-seconds=86400
 
+# Redis
+spring.data.redis.host=localhost
+spring.data.redis.port=6379
+spring.cache.type=redis
 
 logging.level.me.silvernine=DEBUG

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,5 +1,5 @@
-insert into "user" (email, password, name, nickname, is_social, activated) values ('admin@naver.com', '$2a$12$4EbNBPJzszu/DQ11QEgdTuBoxPjZFV0EhOPWusw7FzSYt3.WMjMvK', 'admin', 'admin',1, 1);
-insert into "user" (email, password, name, nickname, is_social, activated) values ('geonHui@naver.com', '$2a$12$kwmjJetpHfDH9IV2843.suBCzpiL.AIyfdKCAG/syMsP.P3KFx/2m', 'geonHui', 'geonHui', 1,1);
+insert into "user" (email, password, name, nickname, is_social) values ('admin@naver.com', '$2a$12$4EbNBPJzszu/DQ11QEgdTuBoxPjZFV0EhOPWusw7FzSYt3.WMjMvK', 'admin', 'admin',1);
+insert into "user" (email, password, name, nickname, is_social) values ('geonHui@naver.com', '$2a$12$kwmjJetpHfDH9IV2843.suBCzpiL.AIyfdKCAG/syMsP.P3KFx/2m', 'geonHui', 'geonHui',1);
 
 insert into authority (authority_name) values ('ROLE_USER');
 insert into authority (authority_name) values ('ROLE_ADMIN');

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,0 +1,9 @@
+insert into "user" (email, password, name, nickname, is_social, activated) values ('admin@naver.com', '$2a$12$4EbNBPJzszu/DQ11QEgdTuBoxPjZFV0EhOPWusw7FzSYt3.WMjMvK', 'admin', 'admin',1, 1);
+insert into "user" (email, password, name, nickname, is_social, activated) values ('geonHui@naver.com', '$2a$12$kwmjJetpHfDH9IV2843.suBCzpiL.AIyfdKCAG/syMsP.P3KFx/2m', 'geonHui', 'geonHui', 1,1);
+
+insert into authority (authority_name) values ('ROLE_USER');
+insert into authority (authority_name) values ('ROLE_ADMIN');
+
+insert into user_authority (user_id, authority_name) values (1, 'ROLE_USER');
+insert into user_authority (user_id, authority_name) values (1, 'ROLE_ADMIN');
+insert into user_authority (user_id, authority_name) values (2, 'ROLE_USER');

--- a/src/test/java/com/WearWeather/wear/auth/AuthServiceTest.java
+++ b/src/test/java/com/WearWeather/wear/auth/AuthServiceTest.java
@@ -58,7 +58,7 @@ public class AuthServiceTest {
     private AuthService authService;
 
     @Test
-    @DisplayName("로그인 시도 시 존재하지 않는 이메일이면 예외를 발생시킨다")
+    @DisplayName("예외 테스트 : 로그인 시 존재하지 않는 이메일")
     public void loginWithNonexistentEmail() {
         // given
         LoginRequest request = new LoginRequest("nonexistent@example.com", "password");
@@ -70,7 +70,7 @@ public class AuthServiceTest {
     }
 
     @Test
-    @DisplayName("로그인 시 비밀번호가 올바르지 않아서 예외를 발생시킨다")
+    @DisplayName("예외 테스트 : 로그인 시 이메일에 맞는 올바르지 않은 비밀번호")
     public void loginWithIncorrectPassword() {
         // given
         User user = User.builder()
@@ -88,7 +88,7 @@ public class AuthServiceTest {
     }
 
     @Test
-    @DisplayName("로그인 성공 시 올바른 응답을 반환한다")
+    @DisplayName("정상 테스트 : 이메일과 패스워드가 일치하여 로그인에 성공한다. ")
     public void successfulLogin() {
         // given
         User user = User.builder()
@@ -118,7 +118,7 @@ public class AuthServiceTest {
     }
 
     @Test
-    @DisplayName("로그인 성공 시 AccessToken, RefreshToken이 생성된다")
+    @DisplayName("정상 테스트 : 로그인 성공 시 AccessToken, RefreshToken이 생성된다.")
     public void tokenCreationOnLogin() {
         // given
         User user = User.builder()
@@ -147,7 +147,7 @@ public class AuthServiceTest {
     }
 
     @Test
-    @DisplayName("로그인 성공 시 refresh token이 Redis에 저장된다")
+    @DisplayName("정상 테스트 : 로그인 성공 시 refresh token이 Redis에 저장되는지 검증한다.")
     public void redisRefreshTokenStorageOnLogin() {
         // given
         User user = User.builder()
@@ -175,7 +175,7 @@ public class AuthServiceTest {
     }
 
     @Test
-    @DisplayName("존재하지 않는 이메일로 로그아웃 시 예외를 발생시킨다")
+    @DisplayName("예외 테스트 : 로그아웃 시 존재하지 않는 이메일")
     public void logoutWithNonexistentEmail() {
         // given
         String email = "nonexistent@example.com";
@@ -188,7 +188,7 @@ public class AuthServiceTest {
     }
 
     @Test
-    @DisplayName("정상적인 로그아웃 시 Redis에서 로그아웃 처리한다")
+    @DisplayName("정상 테스트 :  로그아웃 시 Redis에서 로그아웃 처리하는지 검증한다.")
     public void successfulLogout() {
         // given
         String accessToken = "someAccessToken";
@@ -209,7 +209,7 @@ public class AuthServiceTest {
     }
 
     @Test
-    @DisplayName("유효하지 않은 refresh token으로 재발급 시 예외를 발생시킨다")
+    @DisplayName("예외 테스트 : 유효하지 않은 refresh token으로 재발급 시도하여 예외가 발생한다.")
     public void reissueWithInvalidRefreshToken() {
         // given
         String email = "user@example.com";
@@ -226,7 +226,7 @@ public class AuthServiceTest {
     }
 
     @Test
-    @DisplayName("정상적인 토큰 재발급 시 새로운 access token과 refresh token을 생성한다")
+    @DisplayName("정상 테스트 : 정상적인 토큰 재발급 시 새로운 access token과 refresh token이 생성된다.")
     public void successfulReissueTokens() {
         // given
         String email = "user@example.com";

--- a/src/test/java/com/WearWeather/wear/auth/AuthServiceTest.java
+++ b/src/test/java/com/WearWeather/wear/auth/AuthServiceTest.java
@@ -1,0 +1,144 @@
+package com.WearWeather.wear.auth;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.WearWeather.wear.global.exception.CustomException;
+import com.WearWeather.wear.global.exception.ErrorCode;
+import com.WearWeather.wear.global.jwt.TokenProvider;
+import com.WearWeather.wear.auth.dto.request.LoginRequest;
+import com.WearWeather.wear.auth.dto.response.LoginResponse;
+import com.WearWeather.wear.auth.service.AuthService;
+import com.WearWeather.wear.user.entity.User;
+import com.WearWeather.wear.user.repository.UserRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+
+@ExtendWith(MockitoExtension.class)
+public class AuthServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @Mock
+    private AuthenticationManagerBuilder authenticationManagerBuilder;
+
+    @Mock
+    private AuthenticationManager authenticationManager;
+
+    @Mock
+    private TokenProvider tokenProvider;
+
+    @InjectMocks
+    private AuthService authService;
+
+    @Test
+    @DisplayName("로그인 시도 시 존재하지 않는 이메일이면 예외를 발생시킨다")
+    public void testLoginWithNonexistentEmail() {
+        // given
+        LoginRequest request = new LoginRequest("nonexistent@example.com", "password");
+        when(userRepository.findOneWithAuthoritiesByEmail(anyString())).thenReturn(Optional.empty());
+
+        // when & then
+        CustomException exception = assertThrows(CustomException.class, () -> authService.checkLogin(request));
+        assertEquals(ErrorCode.EMAIL_IS_NULL_EXCEPTION, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("로그인 시 비밀번호가 올바르지 않아서 예외를 발생시킨다")
+    public void testLoginWithIncorrectPassword() {
+        // given
+        User user = User.builder()
+            .email("user@example.com")
+            .password("encodedPassword")
+            .build();
+        LoginRequest request = new LoginRequest("user@example.com", "wrongPassword");
+
+        when(userRepository.findOneWithAuthoritiesByEmail(request.getEmail())).thenReturn(Optional.of(user));
+        when(passwordEncoder.matches(request.getPassword(), user.getPassword())).thenReturn(false);
+
+        // when & then
+        CustomException exception = assertThrows(CustomException.class, () -> authService.checkLogin(request));
+        assertEquals(ErrorCode.PASSWORD_INVALID_EXCEPTION, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("로그인 성공 시 올바른 응답을 반환한다")
+    public void testSuccessfulLogin() {
+        // given
+        User user = User.builder()
+            .email("user@example.com")
+            .password("encodedPassword")
+            .build();
+        LoginRequest request = new LoginRequest("user@example.com", "correctPassword");
+
+        when(userRepository.findOneWithAuthoritiesByEmail(request.getEmail())).thenReturn(Optional.of(user));
+        when(passwordEncoder.matches(request.getPassword(), user.getPassword())).thenReturn(true);
+
+        when(authenticationManagerBuilder.getObject()).thenReturn(authenticationManager);
+        Authentication authentication = mock(Authentication.class);
+        when(authenticationManager.authenticate(any(UsernamePasswordAuthenticationToken.class)))
+            .thenReturn(authentication);
+
+        when(tokenProvider.createToken(any(Authentication.class))).thenReturn("accessToken");
+        when(tokenProvider.createRefreshToken(anyString())).thenReturn("refreshToken");
+
+        // when
+        LoginResponse response = authService.checkLogin(request);
+
+        // then
+        assertNotNull(response);
+        assertEquals("accessToken", response.getAccessToken());
+        assertEquals("refreshToken", response.getRefreshToken());
+    }
+
+    @Test
+    @DisplayName("로그인 성공 시 AccessToken, RefreshToken이 생성된다")
+    public void testTokenCreation() {
+        // given
+        User user = User.builder()
+            .email("user@example.com")
+            .password("encodedPassword")
+            .build();
+        LoginRequest request = new LoginRequest("user@example.com", "correctPassword");
+
+        when(userRepository.findOneWithAuthoritiesByEmail(request.getEmail())).thenReturn(Optional.of(user));
+        when(passwordEncoder.matches(request.getPassword(), user.getPassword())).thenReturn(true);
+
+        when(authenticationManagerBuilder.getObject()).thenReturn(authenticationManager);
+        Authentication authentication = mock(Authentication.class);
+        when(authenticationManager.authenticate(any(UsernamePasswordAuthenticationToken.class)))
+            .thenReturn(authentication);
+
+        when(tokenProvider.createToken(any(Authentication.class))).thenReturn("accessToken");
+        when(tokenProvider.createRefreshToken(anyString())).thenReturn("refreshToken");
+
+        // when
+        authService.checkLogin(request);
+
+        // then
+        verify(tokenProvider).createToken(authentication);
+        verify(tokenProvider).createRefreshToken("user@example.com");
+    }
+
+}

--- a/src/test/java/com/WearWeather/wear/auth/AuthServiceTest.java
+++ b/src/test/java/com/WearWeather/wear/auth/AuthServiceTest.java
@@ -58,7 +58,7 @@ public class AuthServiceTest {
 
     @Test
     @DisplayName("로그인 시도 시 존재하지 않는 이메일이면 예외를 발생시킨다")
-    public void testLoginWithNonexistentEmail() {
+    public void loginWithNonexistentEmail() {
         // given
         LoginRequest request = new LoginRequest("nonexistent@example.com", "password");
         when(userRepository.findOneWithAuthoritiesByEmail(anyString())).thenReturn(Optional.empty());
@@ -70,7 +70,7 @@ public class AuthServiceTest {
 
     @Test
     @DisplayName("로그인 시 비밀번호가 올바르지 않아서 예외를 발생시킨다")
-    public void testLoginWithIncorrectPassword() {
+    public void loginWithIncorrectPassword() {
         // given
         User user = User.builder()
             .email("user@example.com")
@@ -88,7 +88,7 @@ public class AuthServiceTest {
 
     @Test
     @DisplayName("로그인 성공 시 올바른 응답을 반환한다")
-    public void testSuccessfulLogin() {
+    public void successfulLogin() {
         // given
         User user = User.builder()
             .email("user@example.com")
@@ -118,7 +118,7 @@ public class AuthServiceTest {
 
     @Test
     @DisplayName("로그인 성공 시 AccessToken, RefreshToken이 생성된다")
-    public void testTokenCreation() {
+    public void tokenCreationOnLogin() {
         // given
         User user = User.builder()
             .email("user@example.com")
@@ -147,7 +147,7 @@ public class AuthServiceTest {
 
     @Test
     @DisplayName("로그인 성공 시 refresh token이 Redis에 저장된다")
-    public void testRedisRefreshTokenStorage() {
+    public void redisRefreshTokenStorageOnLogin() {
         // given
         User user = User.builder()
             .email("user@example.com")

--- a/src/test/java/com/WearWeather/wear/fixture/UserFixture.java
+++ b/src/test/java/com/WearWeather/wear/fixture/UserFixture.java
@@ -1,0 +1,14 @@
+package com.WearWeather.wear.fixture;
+
+import com.WearWeather.wear.user.entity.User;
+
+public class UserFixture {
+
+    public static User createUser(String email, String password) {
+        return User.builder()
+            .email(email)
+            .password(password)
+            .build();
+    }
+
+}


### PR DESCRIPTION
## 관련 이슈
- #4 

## 작업 동기
- 프로젝트 요구사항에 따른 Jwt를 이용한 로그인,로그아웃, 재발급 API를 구현합니다.

## 세부 작업 사항 
- JWT관련 설정 클래스들 추가
- Spring Security 설정 Config 추가
- Redis 메모리 내 에서 Refresh Toekn을 저장하여 관리하기 위한 Redis 설정 추가
- **로그인**
     - 로그인 요청한 사용자 email DB에 있는지 확인 후, 해당 email에 따른 password 검증
     - 검증 확인되면, 사용자 데이터를 이용한 AccessToekn,RefreshToken 생성
     - AccessToken은 클라이언트에게 반환, RefreshToekn은 Redis inMemory에 기간 설정하여 저장
- **로그아웃**
     - 요청으로 받은 사용자 email 검증 
     - Redis 안에서, 검증된 email을 Key로 가지고 있는 RefreshToekn Value 값 삭제
     - 로그아웃 요청한 사용자의 AccessToekn을  Rdedis 에 Blcaklist 공간 내에 저장
- **토큰 재발급**
     - 요청으로 받은 Refresh Toekn이 Redis 내에 있는 Token과 일치하는지 검증
     - 일치하지 않으면 ' 재 로그인 요청 '
     - 일치하면 새로운 Access Toekn, Refresh Toekn 생성하여 반환
     
## 추후 작업 사항
- [x] 로그아웃, 토큰 재발급 API에 대한 테스트 코드 작성 필요