### PR TITLE
게시글 상세 조회

### DIFF
--- a/src/main/java/com/WearWeather/wear/domain/post/controller/PostController.java
+++ b/src/main/java/com/WearWeather/wear/domain/post/controller/PostController.java
@@ -1,6 +1,7 @@
 package com.WearWeather.wear.domain.post.controller;
 
 import com.WearWeather.wear.domain.post.dto.request.PostCreateRequest;
+import com.WearWeather.wear.domain.post.dto.response.PostDetailResponse;
 import com.WearWeather.wear.domain.post.service.PostService;
 import com.WearWeather.wear.global.common.ResponseMessage;
 import com.WearWeather.wear.global.common.dto.ResponseCommonDTO;
@@ -8,10 +9,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/posts")
@@ -24,5 +22,10 @@ public class PostController {
     public ResponseEntity<ResponseCommonDTO> createPost(@AuthenticationPrincipal UserDetails userDetails, @RequestBody PostCreateRequest request) {
         Long postId = postService.createPost(userDetails.getUsername(), request);
         return ResponseEntity.ok(new ResponseCommonDTO(true, ResponseMessage.SUCCESS_POST));
+    }
+
+    @GetMapping("/{postId}")
+    public ResponseEntity<PostDetailResponse> getPostDetail(@AuthenticationPrincipal UserDetails userDetails, @PathVariable("postId") Long postId) {
+        return ResponseEntity.ok(postService.getPostDetail(userDetails.getUsername(), postId));
     }
 }

--- a/src/main/java/com/WearWeather/wear/domain/post/dto/response/PostDetailResponse.java
+++ b/src/main/java/com/WearWeather/wear/domain/post/dto/response/PostDetailResponse.java
@@ -1,0 +1,48 @@
+package com.WearWeather.wear.domain.post.dto.response;
+
+import com.WearWeather.wear.domain.post.entity.Location;
+import com.WearWeather.wear.domain.post.entity.Post;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+@RequiredArgsConstructor
+@Getter
+@Builder
+public class PostDetailResponse {
+
+    private final String nickname;
+    private final String createAt;
+    private final String title;
+    private final String content;
+    private final List<String> images;
+    private final Location location;
+    private final String seasonTag;
+    private final List<String> weatherTags;
+    private final List<String> temperatureTags;
+    private final boolean likeByUser;
+    private final int likedCount;
+
+    public static PostDetailResponse of(String nickname, Post post, List<String> images, String seasonTag, List<String> weatherTags, List<String> temperatureTags, boolean like){
+
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd HH:mm");
+        String formattedDateTime = post.getCreateAt().format(formatter);
+
+        return PostDetailResponse.builder()
+                .nickname(nickname)
+                .createAt(formattedDateTime)
+                .title(post.getTitle())
+                .content(post.getContent())
+                .location(post.getLocation())
+                .likedCount(post.getLikeCount())
+                .images(images)
+                .seasonTag(seasonTag)
+                .weatherTags(weatherTags)
+                .temperatureTags(temperatureTags)
+                .likeByUser(like)
+                .build();
+    }
+}

--- a/src/main/java/com/WearWeather/wear/domain/postLike/entity/Like.java
+++ b/src/main/java/com/WearWeather/wear/domain/postLike/entity/Like.java
@@ -1,4 +1,4 @@
-package com.WearWeather.wear.domain.post.entity;
+package com.WearWeather.wear.domain.postLike.entity;
 
 import com.WearWeather.wear.global.common.BaseTimeEntity;
 import jakarta.persistence.*;

--- a/src/main/java/com/WearWeather/wear/domain/postLike/repository/LikeRepository.java
+++ b/src/main/java/com/WearWeather/wear/domain/postLike/repository/LikeRepository.java
@@ -1,12 +1,12 @@
 package com.WearWeather.wear.domain.postLike.repository;
 
-import com.WearWeather.wear.domain.post.entity.Like;
+import com.WearWeather.wear.domain.postLike.entity.Like;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-public interface LikeRepository extends JpaRepository<Like, Long> {
-    boolean existsByPostIdAndUserId(Long postId, long userId);
-
+public interface LikeRepository extends JpaRepository<Like, Long>{
     Optional<Like> findByPostIdAndUserId(Long postId, Long userId);
+
+    boolean existsByPostIdAndUserId(Long postId, Long userId);
 }

--- a/src/main/java/com/WearWeather/wear/domain/postLike/service/LikeService.java
+++ b/src/main/java/com/WearWeather/wear/domain/postLike/service/LikeService.java
@@ -1,6 +1,6 @@
 package com.WearWeather.wear.domain.postLike.service;
 
-import com.WearWeather.wear.domain.post.entity.Like;
+import com.WearWeather.wear.domain.postLike.entity.Like;
 import com.WearWeather.wear.domain.post.service.PostService;
 import com.WearWeather.wear.domain.postLike.repository.LikeRepository;
 import com.WearWeather.wear.domain.user.entity.User;
@@ -71,5 +71,5 @@ public class LikeService {
         return likeRepository.findByPostIdAndUserId(postId, userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.NOT_LIKED_POST));
     }
-
 }
+

--- a/src/main/java/com/WearWeather/wear/domain/storage/service/AwsS3Service.java
+++ b/src/main/java/com/WearWeather/wear/domain/storage/service/AwsS3Service.java
@@ -63,6 +63,10 @@ public class AwsS3Service {
         amazonS3.deleteObject(bucket, fileName);
     }
 
+    public String getUrl(String fileName) {
+        return amazonS3.getUrl(bucket, fileName).toString();
+    }
+
     /**
      * 이미지 유효성 체크 후 BufferedImage 반환
      */

--- a/src/main/java/com/WearWeather/wear/domain/user/repository/UserNicknameMapping.java
+++ b/src/main/java/com/WearWeather/wear/domain/user/repository/UserNicknameMapping.java
@@ -1,0 +1,5 @@
+package com.WearWeather.wear.domain.user.repository;
+
+public interface UserNicknameMapping {
+    String getNickname();
+}

--- a/src/main/java/com/WearWeather/wear/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/WearWeather/wear/domain/user/repository/UserRepository.java
@@ -19,4 +19,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByEmailAndNameAndNickname(String email, String name, String nickname);
 
     Optional<User> findByEmail(String email);
+
+    Optional<UserNicknameMapping> findByUserId(Long userId);
 }

--- a/src/main/java/com/WearWeather/wear/domain/user/service/UserService.java
+++ b/src/main/java/com/WearWeather/wear/domain/user/service/UserService.java
@@ -114,4 +114,10 @@ public class UserService {
                 .orElseThrow(() -> new CustomException(ErrorCode.NOT_EXIST_EMAIL));
 
     }
+
+    public String getNicknameById(Long userId){
+        return userRepository.findByUserId(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_EXIST_EMAIL))
+                .getNickname();
+    }
 }

--- a/src/main/java/com/WearWeather/wear/global/exception/ErrorCode.java
+++ b/src/main/java/com/WearWeather/wear/global/exception/ErrorCode.java
@@ -42,6 +42,7 @@ public enum ErrorCode {
     ALREADY_LIKED_POST(BAD_REQUEST, "이미 좋아요된 게시글입니다."),
     NOT_LIKED_POST(BAD_REQUEST, "좋아요한 게시글이 아닙니다."),
     TAG_NOT_FOUND(NOT_FOUND, "태그 아이디가 존재하지 않습니다."),
+    NOT_EXIST_POST_IMAGE(BAD_REQUEST, "존재하지 않는 게시글 이미지입니다."),
     ;
 
     private final HttpStatus httpStatus;


### PR DESCRIPTION
## 개요
게시글 상세 조회

## pr 머지 전 커밋 분리하기 위하여
아직 머지되지않은 브랜치 refactor/post-likes의 최근 커밋_[1]_을 바탕으로 상세 조회 기능 코드를 구현하였는데,
이 브랜치는 부모 브랜치가 refactor/post-likes이므로 상세 조회 기능을 구현한 후 커밋_[2]_, 푸시, pr을 올리면 refactor/post-likes의 커밋 이력인 **[1]+[2]**의 커밋이 합쳐져 보여지게 된다.

현재 브랜치에는 상세 조회 기능 커밋만 따로 구분하고자
메인 브랜치를 부모 브랜치로 두는 feature/get-post-detail 브랜치를 생성하고 **[2]**의 커밋을 Cherry-Pick하여 변경사항을 가져왔다._[3]_
하지만 해당 브랜치는 main브랜치 기반이므로 **[1]**의 내용이 포함되어있지않아 **[3]**을 다시 커밋할 때 **[1]**과 중복되어 커밋되는 부분이 존재한다.

이러한 상황에서는 어떠한 방식으로 해결할 수 있을까요?
