### PR TITLE
게시글 수정, 삭제 기능 구현 

### DIFF
--- a/src/main/java/com/WearWeather/wear/domain/post/controller/PostController.java
+++ b/src/main/java/com/WearWeather/wear/domain/post/controller/PostController.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -33,5 +34,11 @@ public class PostController {
     public ResponseEntity<ResponseCommonDTO> updatePost(@PathVariable Long postId, @RequestBody PostUpdateRequest request) {
         postService.updatePost(postId, request);
         return ResponseEntity.ok(new ResponseCommonDTO(true, ResponseMessage.SUCCESS_UPDATE_POST));
+    }
+
+    @DeleteMapping("/{postId}")
+    public ResponseEntity<ResponseCommonDTO> deletePost(@PathVariable Long postId) {
+        postService.deletePost(postId);
+        return ResponseEntity.ok(new ResponseCommonDTO(true, ResponseMessage.SUCCESS_DELETE_POST));
     }
 }

--- a/src/main/java/com/WearWeather/wear/domain/post/controller/PostController.java
+++ b/src/main/java/com/WearWeather/wear/domain/post/controller/PostController.java
@@ -1,6 +1,7 @@
 package com.WearWeather.wear.domain.post.controller;
 
 import com.WearWeather.wear.domain.post.dto.request.PostCreateRequest;
+import com.WearWeather.wear.domain.post.dto.request.PostUpdateRequest;
 import com.WearWeather.wear.domain.post.service.PostService;
 import com.WearWeather.wear.global.common.ResponseMessage;
 import com.WearWeather.wear.global.common.dto.ResponseCommonDTO;
@@ -8,6 +9,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -24,5 +27,11 @@ public class PostController {
     public ResponseEntity<ResponseCommonDTO> createPost(@AuthenticationPrincipal UserDetails userDetails, @RequestBody PostCreateRequest request) {
         Long postId = postService.createPost(userDetails.getUsername(), request);
         return ResponseEntity.ok(new ResponseCommonDTO(true, ResponseMessage.SUCCESS_POST));
+    }
+
+    @PatchMapping("/{postId}")
+    public ResponseEntity<ResponseCommonDTO> updatePost(@PathVariable Long postId, @RequestBody PostUpdateRequest request) {
+        postService.updatePost(postId, request);
+        return ResponseEntity.ok(new ResponseCommonDTO(true, ResponseMessage.SUCCESS_UPDATE_POST));
     }
 }

--- a/src/main/java/com/WearWeather/wear/domain/post/dto/request/PostUpdateRequest.java
+++ b/src/main/java/com/WearWeather/wear/domain/post/dto/request/PostUpdateRequest.java
@@ -1,7 +1,6 @@
 package com.WearWeather.wear.domain.post.dto.request;
 
 import com.WearWeather.wear.domain.post.entity.Location;
-import com.WearWeather.wear.domain.post.entity.Post;
 import com.WearWeather.wear.domain.postImage.dto.request.PostImageRequest;
 import com.WearWeather.wear.domain.tag.dto.TaggableRequest;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -17,7 +16,7 @@ import lombok.Getter;
 
 @Getter
 @Builder
-public class PostCreateRequest implements PostImageRequest, TaggableRequest {
+public class PostUpdateRequest implements PostImageRequest, TaggableRequest {
 
     @NotBlank
     @Size(max = 50)
@@ -43,7 +42,7 @@ public class PostCreateRequest implements PostImageRequest, TaggableRequest {
     private final List<Long> imageId = new ArrayList<>();
 
     @JsonCreator
-    public PostCreateRequest(
+    public PostUpdateRequest(
         @JsonProperty("title") String title,
         @JsonProperty("content") String content,
         @JsonProperty("location") Location location,
@@ -57,14 +56,5 @@ public class PostCreateRequest implements PostImageRequest, TaggableRequest {
         this.weatherTagIds = weatherTagIds;
         this.temperatureTagIds = temperatureTagIds;
         this.seasonTagId = seasonTagId;
-    }
-
-    public Post toEntity(Long userId) {
-        return Post.builder()
-            .userId(userId)
-            .title(title)
-            .content(content)
-            .location(location)
-            .build();
     }
 }

--- a/src/main/java/com/WearWeather/wear/domain/post/entity/Post.java
+++ b/src/main/java/com/WearWeather/wear/domain/post/entity/Post.java
@@ -86,4 +86,10 @@ public class Post extends BaseTimeEntity implements Serializable {
     public void removeLikeCount() {
         this.likeCount--;
     }
+
+    public void modifyPostAttributes(String title, String content, Location location) {
+        this.title = title;
+        this.content = content;
+        this.location = location;
+    }
 }

--- a/src/main/java/com/WearWeather/wear/domain/post/service/PostService.java
+++ b/src/main/java/com/WearWeather/wear/domain/post/service/PostService.java
@@ -49,6 +49,11 @@ public class PostService {
         postTagService.saveAllTag(post, request);
     }
 
+    public void deletePost(Long postId) {
+        Post post = findById(postId);
+        postRepository.delete(post);
+    }
+
     private void addImagesToPost(PostImageRequest request, Post post) {
         List<PostImage> postImages = postImageRepository.findByIdIn(request.getImageId());
 

--- a/src/main/java/com/WearWeather/wear/domain/postImage/dto/request/PostImageRequest.java
+++ b/src/main/java/com/WearWeather/wear/domain/postImage/dto/request/PostImageRequest.java
@@ -1,0 +1,8 @@
+package com.WearWeather.wear.domain.postImage.dto.request;
+
+import java.util.List;
+
+public interface PostImageRequest {
+
+    List<Long> getImageId();
+}

--- a/src/main/java/com/WearWeather/wear/domain/postTag/repository/PostTagRepository.java
+++ b/src/main/java/com/WearWeather/wear/domain/postTag/repository/PostTagRepository.java
@@ -1,8 +1,10 @@
 package com.WearWeather.wear.domain.postTag.repository;
 
+import com.WearWeather.wear.domain.post.entity.Post;
 import com.WearWeather.wear.domain.postTag.entity.PostTag;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PostTagRepository extends JpaRepository<PostTag, Long> {
 
+    void deleteByPost(Post post);
 }

--- a/src/main/java/com/WearWeather/wear/domain/postTag/service/PostTagService.java
+++ b/src/main/java/com/WearWeather/wear/domain/postTag/service/PostTagService.java
@@ -1,9 +1,9 @@
-package com.WearWeather.wear.domain.tag.service;
+package com.WearWeather.wear.domain.postTag.service;
 
-import com.WearWeather.wear.domain.post.dto.request.PostCreateRequest;
 import com.WearWeather.wear.domain.post.entity.Post;
 import com.WearWeather.wear.domain.postTag.entity.PostTag;
 import com.WearWeather.wear.domain.postTag.repository.PostTagRepository;
+import com.WearWeather.wear.domain.tag.dto.TaggableRequest;
 import com.WearWeather.wear.domain.tag.entity.Tag;
 import com.WearWeather.wear.domain.tag.repository.TagRepository;
 import com.WearWeather.wear.global.exception.CustomException;
@@ -14,12 +14,12 @@ import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-public class TagService {
+public class PostTagService {
 
     private final TagRepository tagRepository;
     private final PostTagRepository postTagRepository;
 
-    public void saveTags(Post post, PostCreateRequest request) {
+    public void saveAllTag(Post post, TaggableRequest request) {
         saveTags(post, request.getWeatherTagIds());
         saveTags(post, request.getTemperatureTagIds());
         saveTag(post, request.getSeasonTagId());
@@ -41,4 +41,9 @@ public class TagService {
         postTagRepository.save(postTag);
         post.addPostTag(postTag);
     }
+
+    public void deleteTagsByPost(Post post) {
+        postTagRepository.deleteByPost(post);
+    }
+
 }

--- a/src/main/java/com/WearWeather/wear/domain/tag/dto/TaggableRequest.java
+++ b/src/main/java/com/WearWeather/wear/domain/tag/dto/TaggableRequest.java
@@ -1,0 +1,12 @@
+package com.WearWeather.wear.domain.tag.dto;
+
+import java.util.Set;
+
+public interface TaggableRequest {
+
+    Set<Long> getWeatherTagIds();
+
+    Set<Long> getTemperatureTagIds();
+
+    Long getSeasonTagId();
+}

--- a/src/main/java/com/WearWeather/wear/global/common/ResponseMessage.java
+++ b/src/main/java/com/WearWeather/wear/global/common/ResponseMessage.java
@@ -11,7 +11,9 @@ public class ResponseMessage {
     public static final String MODIFY_USERINFO = "회원정보 수정 완료하였습니다.";
     public static final String SUCCESS_POST_LIKE = "게시글 좋아요 등록 성공하였습니다.";
     public static final String SUCCESS_POST_LIKE_CANCEL = "게시글 좋아요 취소하였습니다.";
-    public static final String SUCCESS_POST = "게시물 생성 완료";
+    public static final String SUCCESS_POST = "게시물 생성 완료하였습니다.";
+    public static final String SUCCESS_UPDATE_POST = "게시물 수정 완료하였습니다.";
+    public static final String SUCCESS_DELETE_POST = "게시물 삭제 완료하였습니다.";
 
 
 }


### PR DESCRIPTION
## 개요
- 게시물 수정,삭제에 대한 기능을 구현합니다.

## 주요 작업 내용
- 아래 상황에 따라 게시글 수정 기능 구현
  1. 사용자 게시글 생성 시에 저장된 이미지 1,2이 DB,S3에 저장되어있다고 가정
  2. 사용자 게시글 수정 시에 이미지 1은 유지, 이미지 2는 삭제, 이미지 3은 추가 한다고 가정
  3. 프론트 쪽에서 게시글 수정 데이터 보내줄 때, 새롭게 추가한 이미지Id만을 보내주는 것이 가능

- 게시글 id를 삭제하는 것을 통한 게시글 삭제