### PR TITLE
연관된 Entity들 연관 객체 대신 외래키 필드를 사용하도록 리펙토링

### DIFF
--- a/src/main/java/com/WearWeather/wear/domain/post/dto/request/PostCreateRequest.java
+++ b/src/main/java/com/WearWeather/wear/domain/post/dto/request/PostCreateRequest.java
@@ -31,11 +31,11 @@ public class PostCreateRequest implements PostImageRequest, TaggableRequest {
     @Valid
     private final Location location;
 
-    @NotBlank
+    @NotNull
     @Size(max = 2)
     private final Set<Long> weatherTagIds;
 
-    @NotBlank
+    @NotNull
     @Size(max = 2)
     private final Set<Long> temperatureTagIds;
 

--- a/src/main/java/com/WearWeather/wear/domain/post/dto/request/PostUpdateRequest.java
+++ b/src/main/java/com/WearWeather/wear/domain/post/dto/request/PostUpdateRequest.java
@@ -28,11 +28,11 @@ public class PostUpdateRequest implements PostImageRequest, TaggableRequest {
 
     private final Location location;
 
-    @NotBlank
+    @NotNull
     @Size(max = 2)
     private final Set<Long> weatherTagIds;
 
-    @NotBlank
+    @NotNull
     @Size(max = 2)
     private final Set<Long> temperatureTagIds;
 

--- a/src/main/java/com/WearWeather/wear/domain/post/dto/response/TopLikedPostDetailResponse.java
+++ b/src/main/java/com/WearWeather/wear/domain/post/dto/response/TopLikedPostDetailResponse.java
@@ -1,12 +1,12 @@
 package com.WearWeather.wear.domain.post.dto.response;
+
 import com.WearWeather.wear.domain.post.entity.Location;
 import com.WearWeather.wear.domain.post.entity.Post;
+import java.util.List;
+import java.util.Map;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-
-import java.util.List;
-import java.util.Map;
 
 @RequiredArgsConstructor
 @Getter
@@ -21,16 +21,16 @@ public class TopLikedPostDetailResponse {
     private final List<Long> temperatureTagIds;
     private final boolean likeByUser;
 
-    public static TopLikedPostDetailResponse of(Post post, String url, Map<String, List<Long>> tags, boolean like){
+    public static TopLikedPostDetailResponse of(Post post, String url, Map<String, List<Long>> tags, boolean like) {
         return TopLikedPostDetailResponse.builder()
-                .postId(post.getPostId())
-                .thumbnail(url)
-                .location(post.getLocation())
-                .seasonTagId(tags.get("SEASON").get(0))
-                .weatherTagIds(tags.get("WEATHER"))
-                .temperatureTagIds(tags.get("TEMPERATURE"))
-                .likeByUser(like)
-                .build();
+            .postId(post.getId())
+            .thumbnail(url)
+            .location(post.getLocation())
+            .seasonTagId(tags.get("SEASON").get(0))
+            .weatherTagIds(tags.get("WEATHER"))
+            .temperatureTagIds(tags.get("TEMPERATURE"))
+            .likeByUser(like)
+            .build();
     }
 
 }

--- a/src/main/java/com/WearWeather/wear/domain/post/entity/Post.java
+++ b/src/main/java/com/WearWeather/wear/domain/post/entity/Post.java
@@ -1,9 +1,6 @@
 package com.WearWeather.wear.domain.post.entity;
 
-import com.WearWeather.wear.domain.postImage.entity.PostImage;
-import com.WearWeather.wear.domain.postTag.entity.PostTag;
 import com.WearWeather.wear.global.common.BaseTimeEntity;
-import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
@@ -11,16 +8,12 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
-import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.BatchSize;
 
 @AllArgsConstructor
 @NoArgsConstructor
@@ -33,7 +26,7 @@ public class Post extends BaseTimeEntity implements Serializable {
     @Id
     @Column(name = "post_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long postId;
+    private Long id;
 
     @Column(name = "user_id", nullable = false)
     private Long userId;
@@ -56,24 +49,6 @@ public class Post extends BaseTimeEntity implements Serializable {
 
     @Column(name = "thumbnail_image_id")
     private Long thumbnailImageId; // 대표 이미지 ID 필드
-
-    @Builder.Default
-    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<PostTag> postTags = new ArrayList<>();
-
-    @BatchSize(size = 100)
-    @Builder.Default
-    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<PostImage> postImages = new ArrayList<>();
-
-    public void addPostImages(PostImage postImage) {
-        this.postImages.add(postImage);
-        postImage.addPost(this);
-    }
-
-    public void addPostTag(PostTag postTag) {
-        this.postTags.add(postTag);
-    }
 
     public void addThumbnailImageId(Long postImageId) {
         this.thumbnailImageId = postImageId;

--- a/src/main/java/com/WearWeather/wear/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/WearWeather/wear/domain/post/repository/PostRepository.java
@@ -2,14 +2,15 @@ package com.WearWeather.wear.domain.post.repository;
 
 import com.WearWeather.wear.domain.post.entity.Location;
 import com.WearWeather.wear.domain.post.entity.Post;
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.List;
-
 public interface PostRepository extends JpaRepository<Post, Long> {
-    List<Post> findAllByPostIdInOrderByLikeCountDesc(List<Long> postIdList);
+
+    List<Post> findAllByIdInOrderByLikeCountDesc(List<Long> postIdList);
+
     Page<Post> findAllByLocation(Pageable pageable, Location location);
 
 }

--- a/src/main/java/com/WearWeather/wear/domain/post/service/PostService.java
+++ b/src/main/java/com/WearWeather/wear/domain/post/service/PostService.java
@@ -1,11 +1,12 @@
 package com.WearWeather.wear.domain.post.service;
 
 import com.WearWeather.wear.domain.post.dto.request.PostCreateRequest;
-import com.WearWeather.wear.domain.post.dto.response.TopLikedPostDetailResponse;
-import com.WearWeather.wear.domain.post.dto.request.PostsByLocationRequest;
-import com.WearWeather.wear.domain.post.dto.response.*;
-import com.WearWeather.wear.domain.post.dto.response.PostDetailResponse;
 import com.WearWeather.wear.domain.post.dto.request.PostUpdateRequest;
+import com.WearWeather.wear.domain.post.dto.request.PostsByLocationRequest;
+import com.WearWeather.wear.domain.post.dto.response.PostDetailByLocationResponse;
+import com.WearWeather.wear.domain.post.dto.response.PostDetailResponse;
+import com.WearWeather.wear.domain.post.dto.response.PostsByLocationResponse;
+import com.WearWeather.wear.domain.post.dto.response.TopLikedPostDetailResponse;
 import com.WearWeather.wear.domain.post.entity.Post;
 import com.WearWeather.wear.domain.post.entity.SortType;
 import com.WearWeather.wear.domain.post.repository.PostRepository;
@@ -14,19 +15,19 @@ import com.WearWeather.wear.domain.postImage.entity.PostImage;
 import com.WearWeather.wear.domain.postImage.repository.PostImageRepository;
 import com.WearWeather.wear.domain.postLike.repository.LikeRepository;
 import com.WearWeather.wear.domain.postTag.entity.PostTag;
+import com.WearWeather.wear.domain.postTag.repository.PostTagRepository;
+import com.WearWeather.wear.domain.postTag.service.PostTagService;
 import com.WearWeather.wear.domain.storage.service.AwsS3Service;
 import com.WearWeather.wear.domain.tag.entity.Tag;
 import com.WearWeather.wear.domain.tag.repository.TagRepository;
-import com.WearWeather.wear.domain.postTag.service.PostTagService;
 import com.WearWeather.wear.domain.user.entity.User;
 import com.WearWeather.wear.domain.user.service.UserService;
 import com.WearWeather.wear.global.exception.CustomException;
 import com.WearWeather.wear.global.exception.ErrorCode;
 import java.util.List;
-
-import java.util.*;
+import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
-
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -46,6 +47,7 @@ public class PostService {
     private final UserService userService;
     private final LikeRepository likeRepository;
     private final AwsS3Service awsS3Service;
+    private final PostTagRepository postTagRepository;
 
     private static final String SORT_COLUMN_BY_CREATE_AT = "createAt";
     private static final String SORT_COLUMN_BY_LIKE_COUNT = "likeCount";
@@ -55,10 +57,12 @@ public class PostService {
         User user = userService.getUserByEmail(email);
         Post post = request.toEntity(user.getUserId());
 
-        addImagesToPost(request, post);
-        postTagService.saveAllTag(post, request);
+        postRepository.save(post);
 
-        return post.getPostId();
+        updateImagesInPost(request, post);
+        postTagService.saveAllTag(post.getId(), request);
+
+        return post.getId();
     }
 
     @Transactional
@@ -66,12 +70,10 @@ public class PostService {
         Post post = findById(postId);
         post.modifyPostAttributes(request.getTitle(), request.getContent(), request.getLocation());
 
-        addImagesToPost(request, post);
+        updateImagesInPost(request, post);
 
-        postTagService.deleteTagsByPost(post);
-        post.getPostTags().clear();
-
-        postTagService.saveAllTag(post, request);
+        postTagService.deleteTagsByPost(postId);
+        postTagService.saveAllTag(postId, request);
     }
 
     @Transactional
@@ -80,15 +82,15 @@ public class PostService {
         postRepository.delete(post);
     }
 
-    private void addImagesToPost(PostImageRequest request, Post post) {
+    private void updateImagesInPost(PostImageRequest request, Post post) {
         List<PostImage> postImages = postImageRepository.findByIdIn(request.getImageId());
 
         for (int i = 0; i < postImages.size(); i++) {
             PostImage postImage = postImages.get(i);
-            if (postImage.getPost() != null) {
+            if (postImage.getPostId() != null) {
                 throw new CustomException(ErrorCode.INVALID_IMAGE_IMAGE);
             }
-            post.addPostImages(postImage);
+            postImage.updatePostId(post.getId());
 
             if (i == 0) {
                 post.addThumbnailImageId(postImage.getId());
@@ -119,136 +121,128 @@ public class PostService {
             .orElseThrow(() -> new CustomException(ErrorCode.NOT_EXIST_POST));
     }
 
-    public List<TopLikedPostDetailResponse> getTopLikedPosts(String email){
-
+    public List<TopLikedPostDetailResponse> getTopLikedPosts(String email) {
         User user = userService.getUserByEmail(email);
-
         List<Post> posts = getPostsOrderByLikeCountDesc();
 
         return posts.stream()
-                .map(post -> getTopLikedPostDetail(post, user.getUserId()))
-                .collect(Collectors.toList());
+            .map(post -> getTopLikedPostDetail(post, user.getUserId()))
+            .collect(Collectors.toList());
     }
 
-    public List<Post> getPostsOrderByLikeCountDesc(){
-
+    public List<Post> getPostsOrderByLikeCountDesc() {
         List<Long> postIds = likeRepository.findMostLikedPostIdForDay();
-        return postRepository.findAllByPostIdInOrderByLikeCountDesc(postIds);
+
+        return postRepository.findAllByIdInOrderByLikeCountDesc(postIds);
     }
 
-    public TopLikedPostDetailResponse getTopLikedPostDetail(Post post, Long userId){
-
+    public TopLikedPostDetailResponse getTopLikedPostDetail(Post post, Long userId) {
         String url = getImageUrl(post.getThumbnailImageId());
 
-        Map<String, List<Long>> tags = getTagsByPostId(post.getPostTags());
+        Map<String, List<Long>> tags = getTagsByPostId(post.getId());
 
-        boolean like = checkLikeByPostAndUser(post.getPostId(), userId);
+        boolean like = checkLikeByPostAndUser(post.getId(), userId);
 
         return TopLikedPostDetailResponse.of(
-                post,
-                url,
-                tags,
-                like);
+            post,
+            url,
+            tags,
+            like);
     }
 
     public PostDetailResponse getPostDetail(String email, Long postId) {
-
         User user = userService.getUserByEmail(email);
         String postUserNickname = userService.getNicknameById(user.getUserId());
 
         Post post = findById(postId);
-        List<String> imageUrlList = getImageUrlList(post.getPostImages());
-        Map<String, List<Long>> tags = getTagsByPostId(post.getPostTags());
+        List<String> imageUrlList = getImageUrlList(post.getId());
+        Map<String, List<Long>> tags = getTagsByPostId(post.getId());
 
-        boolean like = checkLikeByPostAndUser(post.getPostId(), user.getUserId());
+        boolean like = checkLikeByPostAndUser(post.getId(), user.getUserId());
 
         return PostDetailResponse.of(
-                postUserNickname,
-                post,
-                imageUrlList,
-                tags,
-                like);
+            postUserNickname,
+            post,
+            imageUrlList,
+            tags,
+            like);
     }
 
-    public List<String> getImageUrlList(List<PostImage> postImages){
+    public List<String> getImageUrlList(Long postId) {
+        List<PostImage> postImages = postImageRepository.findByPostId(postId);
         return postImages.stream()
-                .map(image -> getImageUrl(image.getId()))
-                .toList();
+            .map(image -> getImageUrl(image.getId()))
+            .toList();
     }
 
-    public String getImageUrl(Long thumbnailId){
+    public String getImageUrl(Long thumbnailId) {
         PostImage postImage = postImageRepository.findById(thumbnailId)
-                .orElseThrow(() -> new CustomException(ErrorCode.NOT_EXIST_POST_IMAGE));
+            .orElseThrow(() -> new CustomException(ErrorCode.NOT_EXIST_POST_IMAGE));
 
         return awsS3Service.getUrl(postImage.getName());
     }
 
-    public Map<String, List<Long>> getTagsByPostId(List<PostTag> postTags) {
+    public Map<String, List<Long>> getTagsByPostId(Long postId) {
+        List<PostTag> postTags = postTagRepository.findByPostId(postId);
 
         List<Long> tagIds = postTags.stream()
-                .map(postTag -> postTag.getTag().getTagId())
-                .collect(Collectors.toList());
+            .map(PostTag::getTagId)
+            .collect(Collectors.toList());
 
         List<Tag> tags = tagRepository.findAllById(tagIds);
 
         return tags.stream()
-                .collect(Collectors.groupingBy(
-                        Tag::getCategory,
-                        Collectors.mapping(Tag::getTagId, Collectors.toList())
-                ));
+            .collect(Collectors.groupingBy(
+                Tag::getCategory,
+                Collectors.mapping(Tag::getTagId, Collectors.toList())
+            ));
     }
 
-    public boolean checkLikeByPostAndUser(Long postId, Long userId){
+    public boolean checkLikeByPostAndUser(Long postId, Long userId) {
         return likeRepository.existsByPostIdAndUserId(postId, userId);
     }
 
     public PostsByLocationResponse getPostsByLocation(String email, PostsByLocationRequest request) {
-
         User user = userService.getUserByEmail(email);
-
         List<PostDetailByLocationResponse> responses = getPostDetailByLocation(request, user.getUserId());
 
         return PostsByLocationResponse.of(request.getLocation(), responses);
     }
 
-    public List<PostDetailByLocationResponse> getPostDetailByLocation(PostsByLocationRequest request, Long userId){
-
+    public List<PostDetailByLocationResponse> getPostDetailByLocation(PostsByLocationRequest request, Long userId) {
         String sortType = getSortColumnName(request.getSort());
 
         Pageable pageable = PageRequest.of(request.getPage(), request.getSize(), Sort.by(sortType).descending());
         Page<Post> posts = postRepository.findAllByLocation(pageable, request.getLocation());
 
         return posts.stream()
-                .map(post -> getPostDetailByLocation(post, userId))
-                .toList();
+            .map(post -> getPostDetailByLocation(post, userId))
+            .toList();
     }
 
-    public String getSortColumnName(SortType sortType){
-
-        if(Objects.equals(sortType, SortType.LATEST)){
+    public String getSortColumnName(SortType sortType) {
+        if (Objects.equals(sortType, SortType.LATEST)) {
             return SORT_COLUMN_BY_CREATE_AT;
         }
 
-        if(Objects.equals(sortType, SortType.RECOMMENDED)){
+        if (Objects.equals(sortType, SortType.RECOMMENDED)) {
             return SORT_COLUMN_BY_LIKE_COUNT;
         }
 
         return SORT_COLUMN_BY_CREATE_AT;
     }
 
-    public PostDetailByLocationResponse getPostDetailByLocation(Post post, Long userId){
-
+    public PostDetailByLocationResponse getPostDetailByLocation(Post post, Long userId) {
         String url = getImageUrl(post.getThumbnailImageId());
+        Map<String, List<Long>> tags = getTagsByPostId(post.getId());
 
-        Map<String, List<Long>> tags = getTagsByPostId(post.getPostTags());
-
-        boolean like = checkLikeByPostAndUser(post.getPostId(), userId);
+        boolean like = checkLikeByPostAndUser(post.getId(), userId);
 
         return PostDetailByLocationResponse.of(
-                post.getPostId(),
-                url,
-                tags,
-                like
+            post.getId(),
+            url,
+            tags,
+            like
         );
     }
 }

--- a/src/main/java/com/WearWeather/wear/domain/postImage/entity/PostImage.java
+++ b/src/main/java/com/WearWeather/wear/domain/postImage/entity/PostImage.java
@@ -1,16 +1,12 @@
 package com.WearWeather.wear.domain.postImage.entity;
 
 
-import com.WearWeather.wear.domain.post.entity.Post;
 import com.WearWeather.wear.global.common.BaseTimeEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
 import java.io.Serializable;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -26,9 +22,8 @@ public class PostImage extends BaseTimeEntity implements Serializable {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "post_id")
-    private Post post;
+    @Column(name = "post_id")
+    private Long postId;
 
     @Column(nullable = false)
     private String name;         // s3에 저장된 이름
@@ -43,8 +38,8 @@ public class PostImage extends BaseTimeEntity implements Serializable {
     private int height;
 
     @Builder
-    public PostImage(Post post, String name, String originName, int byteSize, int width, int height) {
-        this.post = post;
+    public PostImage(Long postId, String name, String originName, int byteSize, int width, int height) {
+        this.postId = postId;
         this.name = name;
         this.originName = originName;
         this.byteSize = byteSize;
@@ -52,7 +47,7 @@ public class PostImage extends BaseTimeEntity implements Serializable {
         this.height = height;
     }
 
-    public void addPost(Post post) {
-        this.post = post;
+    public void updatePostId(Long postId) {
+        this.postId = postId;
     }
 }

--- a/src/main/java/com/WearWeather/wear/domain/postImage/repository/PostImageRepository.java
+++ b/src/main/java/com/WearWeather/wear/domain/postImage/repository/PostImageRepository.java
@@ -8,5 +8,7 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface PostImageRepository extends JpaRepository<PostImage, Long> {
 
+    List<PostImage> findByPostId(Long postId);
+
     List<PostImage> findByIdIn(List<Long> ids);
 }

--- a/src/main/java/com/WearWeather/wear/domain/postImage/service/PostImageService.java
+++ b/src/main/java/com/WearWeather/wear/domain/postImage/service/PostImageService.java
@@ -21,7 +21,7 @@ public class PostImageService {
     @Transactional
     public Long createPostImage(MultipartFile multipartFile, ImageInfoDto imageInfoDto) {
         PostImage postImage = PostImage.builder()
-            .post(null)
+            .postId(null)
             .name(imageInfoDto.getS3Name())
             .originName(multipartFile.getOriginalFilename())
             .byteSize((int) multipartFile.getSize())

--- a/src/main/java/com/WearWeather/wear/domain/postTag/entity/PostTag.java
+++ b/src/main/java/com/WearWeather/wear/domain/postTag/entity/PostTag.java
@@ -1,14 +1,10 @@
 package com.WearWeather.wear.domain.postTag.entity;
 
-import com.WearWeather.wear.domain.post.entity.Post;
-import com.WearWeather.wear.domain.tag.entity.Tag;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -25,17 +21,15 @@ public class PostTag {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "post_id")
-    private Post post;
+    @Column(name = "post_id", nullable = false)
+    private Long postId;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "tag_id")
-    private Tag tag;
+    @Column(name = "tag_id", nullable = false)
+    private Long tagId;
 
     @Builder
-    public PostTag(Post post, Tag tag) {
-        this.post = post;
-        this.tag = tag;
+    public PostTag(Long postId, Long tagId) {
+        this.postId = postId;
+        this.tagId = tagId;
     }
 }

--- a/src/main/java/com/WearWeather/wear/domain/postTag/repository/PostTagRepository.java
+++ b/src/main/java/com/WearWeather/wear/domain/postTag/repository/PostTagRepository.java
@@ -1,10 +1,12 @@
 package com.WearWeather.wear.domain.postTag.repository;
 
-import com.WearWeather.wear.domain.post.entity.Post;
 import com.WearWeather.wear.domain.postTag.entity.PostTag;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PostTagRepository extends JpaRepository<PostTag, Long> {
 
-    void deleteByPost(Post post);
+    List<PostTag> findByPostId(Long postId);
+
+    void deleteByPostId(Long postId);
 }

--- a/src/main/java/com/WearWeather/wear/domain/postTag/service/PostTagService.java
+++ b/src/main/java/com/WearWeather/wear/domain/postTag/service/PostTagService.java
@@ -1,6 +1,5 @@
 package com.WearWeather.wear.domain.postTag.service;
 
-import com.WearWeather.wear.domain.post.entity.Post;
 import com.WearWeather.wear.domain.postTag.entity.PostTag;
 import com.WearWeather.wear.domain.postTag.repository.PostTagRepository;
 import com.WearWeather.wear.domain.tag.dto.TaggableRequest;
@@ -19,31 +18,29 @@ public class PostTagService {
     private final TagRepository tagRepository;
     private final PostTagRepository postTagRepository;
 
-    public void saveAllTag(Post post, TaggableRequest request) {
-        saveTags(post, request.getWeatherTagIds());
-        saveTags(post, request.getTemperatureTagIds());
-        saveTag(post, request.getSeasonTagId());
+    public void saveAllTag(Long postId, TaggableRequest request) {
+        saveTags(postId, request.getWeatherTagIds());
+        saveTags(postId, request.getTemperatureTagIds());
+        saveTag(postId, request.getSeasonTagId());
     }
 
-    private void saveTags(Post post, Set<Long> tagIds) {
+    private void saveTags(Long postId, Set<Long> tagIds) {
         for (Long tagId : tagIds) {
-            saveTag(post, tagId);
+            saveTag(postId, tagId);
         }
     }
 
-    private void saveTag(Post post, Long tagId) {
+    private void saveTag(Long postId, Long tagId) {
         Tag tag = tagRepository.findById(tagId)
             .orElseThrow(() -> new CustomException(ErrorCode.TAG_NOT_FOUND));
         PostTag postTag = PostTag.builder()
-            .post(post)
-            .tag(tag)
+            .postId(postId)
+            .tagId(tagId)
             .build();
         postTagRepository.save(postTag);
-        post.addPostTag(postTag);
     }
 
-    public void deleteTagsByPost(Post post) {
-        postTagRepository.deleteByPost(post);
+    public void deleteTagsByPost(Long postId) {
+        postTagRepository.deleteByPostId(postId);
     }
-
 }

--- a/src/test/java/com/WearWeather/wear/domain/postLike/LikeServiceTest.java
+++ b/src/test/java/com/WearWeather/wear/domain/postLike/LikeServiceTest.java
@@ -1,8 +1,15 @@
 package com.WearWeather.wear.domain.postLike;
 
-import com.WearWeather.wear.domain.postLike.entity.Like;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import com.WearWeather.wear.domain.post.entity.Post;
 import com.WearWeather.wear.domain.post.service.PostService;
+import com.WearWeather.wear.domain.postLike.entity.Like;
 import com.WearWeather.wear.domain.postLike.repository.LikeRepository;
 import com.WearWeather.wear.domain.postLike.service.LikeService;
 import com.WearWeather.wear.domain.user.entity.User;
@@ -10,17 +17,13 @@ import com.WearWeather.wear.domain.user.service.UserService;
 import com.WearWeather.wear.fixture.UserFixture;
 import com.WearWeather.wear.global.exception.CustomException;
 import com.WearWeather.wear.global.exception.ErrorCode;
+import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
-import java.util.Optional;
-
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
 
 @DisplayName("UserService 테스트")
 @ExtendWith(MockitoExtension.class)
@@ -111,10 +114,10 @@ public class LikeServiceTest {
         String userEmail = UserFixture.email;
 
         when(userService.getUserByEmail(userEmail)).thenReturn(user);
-        when(likeRepository.findByPostIdAndUserId(post.getPostId(), user.getUserId())).thenReturn(Optional.empty());
+        when(likeRepository.findByPostIdAndUserId(post.getId(), user.getUserId())).thenReturn(Optional.empty());
 
         CustomException exception = assertThrows(CustomException.class, () ->
-                likeService.removeLike(post.getPostId(), userEmail));
+            likeService.removeLike(post.getId(), userEmail));
         assertEquals(ErrorCode.NOT_LIKED_POST, exception.getErrorCode());
     }
 }


### PR DESCRIPTION

## 작업 동기
**기존 방식**
- Post 엔티티가 @OneToMany 관계로 PostTag 및 PostImage와 연결되어 있고, @OneToMany는 fetch = FetchType.LAZY로 설정한 방식으로 구현되어 있다.
- 위의 방식은 Post 엔티티를 조회할 때마다 연관된 PostTag 및 PostImage를 개별적으로 조회하는 쿼리가 발생할 수 있다.
  - ex) Post를 10개 가져온다고 하면, 각 Post에 대해 추가적으로 PostTag와 PostImage를 가져오는 쿼리가 각각 발생될 수 있고, 이로 인해 총 1+10+10=21개의 쿼리가 실행될 수 있다.
- 즉, N+1의 문제가 발생될 수 있다.

위의 문제에 대한 해결 방안으로 @EntityGraph 또는 Fetch Join, Batch Size을 사용하여 연관 객체를 사용하는 것에 있는 문제 해결이 가능하지만, 코드 복잡성 향상의 단점으로 인해 불필요한 추가 쿼리를 방지하고 성능을 최적화가 가능한 **외래키 필드를 직접 사용하는 방식**으로 리팩토링을 진행합니다.


## 세부 작업 사항 
- Post, PostImage, PostTag Entity 리펙토링
- 코드 수정에 따른 비즈니스 로직 수정

## 추후 개선 사항
- 지금은 기능이 작동되도록 구현해놓은 상태이고, 비즈니스 로직 객체 지향 관점에서 더 좋은 코드로 리펙토링이 가능할 것으로 보입니다.
-  브랜치 목적에 맞는 리펙토링을 진행 후, 추후에 비즈니스 로직 관련된 리펙토링을 진행하는 것으로 하면 좋을 것 같습니다.
