### PR TITLE
지역 초기 데이터 저장하기

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,6 +67,9 @@ dependencies {
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
+    implementation 'com.fasterxml.jackson.core:jackson-databind'
+
+
 }
 
 def querydslSrcDir = 'src/main/generated'

--- a/src/main/java/com/WearWeather/wear/domain/location/controller/LocationController.java
+++ b/src/main/java/com/WearWeather/wear/domain/location/controller/LocationController.java
@@ -1,0 +1,19 @@
+package com.WearWeather.wear.domain.location.controller;
+
+import com.WearWeather.wear.domain.location.service.LocationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/location")
+public class LocationController {
+
+    private final LocationService locationService;
+
+    @GetMapping
+    public void getLocationData() throws Exception {
+        locationService.getLocationData();
+    }
+
+}

--- a/src/main/java/com/WearWeather/wear/domain/location/controller/LocationController.java
+++ b/src/main/java/com/WearWeather/wear/domain/location/controller/LocationController.java
@@ -12,7 +12,7 @@ public class LocationController {
     private final LocationService locationService;
 
     @GetMapping
-    public void getLocationData() throws Exception {
+    public void getLocationDistrictData() throws Exception {
         locationService.getLocationData();
     }
 

--- a/src/main/java/com/WearWeather/wear/domain/location/entity/City.java
+++ b/src/main/java/com/WearWeather/wear/domain/location/entity/City.java
@@ -1,0 +1,24 @@
+package com.WearWeather.wear.domain.location.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Getter
+@Entity
+public class City {
+
+    @Id
+    @Column(name = "city_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String city;
+
+}

--- a/src/main/java/com/WearWeather/wear/domain/location/entity/District.java
+++ b/src/main/java/com/WearWeather/wear/domain/location/entity/District.java
@@ -1,0 +1,28 @@
+package com.WearWeather.wear.domain.location.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Entity
+public class District {
+
+    @Id
+    @Column(name = "district_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long cityId;
+
+    @Column(nullable = false)
+    private String district;
+
+    @Builder
+    public District(Long cityId, String district) {
+        this.cityId = cityId;
+        this.district = district;
+    }
+}

--- a/src/main/java/com/WearWeather/wear/domain/location/repository/CityRepository.java
+++ b/src/main/java/com/WearWeather/wear/domain/location/repository/CityRepository.java
@@ -1,0 +1,8 @@
+package com.WearWeather.wear.domain.location.repository;
+
+import com.WearWeather.wear.domain.location.entity.City;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CityRepository extends JpaRepository<City, Long> {
+
+}

--- a/src/main/java/com/WearWeather/wear/domain/location/repository/DistrictRepository.java
+++ b/src/main/java/com/WearWeather/wear/domain/location/repository/DistrictRepository.java
@@ -1,0 +1,7 @@
+package com.WearWeather.wear.domain.location.repository;
+
+import com.WearWeather.wear.domain.location.entity.District;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DistrictRepository extends JpaRepository<District, Long> {
+}

--- a/src/main/java/com/WearWeather/wear/domain/location/service/LocationService.java
+++ b/src/main/java/com/WearWeather/wear/domain/location/service/LocationService.java
@@ -1,0 +1,72 @@
+package com.WearWeather.wear.domain.location.service;
+
+import com.WearWeather.wear.domain.location.entity.City;
+import com.WearWeather.wear.domain.location.entity.District;
+import com.WearWeather.wear.domain.location.repository.CityRepository;
+import com.WearWeather.wear.domain.location.repository.DistrictRepository;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class LocationService {
+
+    @Value("${location.api.key}")
+    private String openApiKey;
+
+    private final CityRepository cityRepository;
+    private final DistrictRepository districtRepository;
+    private final RestTemplate restTemplate;
+    ObjectMapper objectMapper = new ObjectMapper();
+
+    public void getLocationData() throws Exception  {
+
+        List<City> cityList = cityRepository.findAll();
+
+        for ( City city : cityList) {
+            String apiUrl = "https://api.vworld.kr/req/data?service=data" +
+                    "&request=GetFeature" +
+                    "&data=LT_C_ADSIGG_INFO" +
+                    "&key=" + openApiKey +
+                    "&format=json" +
+                    "&attrFilter=full_nm:like:" + city.getCity() +
+                    "&geometry=false";
+
+            String responseBody = restTemplate.getForEntity(apiUrl, String.class).getBody();
+
+            if (responseBody != null) {
+                JsonNode root = objectMapper.readTree(responseBody);
+                JsonNode features = root.path("response")
+                        .path("result")
+                        .path("featureCollection")
+                        .path("features");
+
+                Set<String> uniqueDistricts = new HashSet<>();
+
+                for (JsonNode feature : features) {
+                    JsonNode properties = feature.path("properties");
+                    String districtName = properties.path("sig_kor_nm").asText();
+
+                    String processedDistrictName = (districtName.length() > 3)
+                            ? districtName.substring(0, 3)
+                            : districtName;
+
+                    uniqueDistricts.add(processedDistrictName);
+                }
+
+                List<District> districtsToSave = uniqueDistricts.stream()
+                        .map(districtName -> new District(city.getId(), districtName))
+                        .collect(Collectors.toList());
+
+                districtRepository.saveAll(districtsToSave);
+            }
+        }
+    }
+}

--- a/src/main/java/com/WearWeather/wear/domain/post/entity/Location.java
+++ b/src/main/java/com/WearWeather/wear/domain/post/entity/Location.java
@@ -9,15 +9,15 @@ import lombok.Getter;
 public class Location {
 
     @Column(nullable = false)
-    private String city;
+    private Long city;
 
     @Column(nullable = false)
-    private String district;
+    private Long district;
 
     public Location() {
     }
 
-    public Location(String city, String district) {
+    public Location(Long city, Long district) {
         this.city = city;
         this.district = district;
     }

--- a/src/main/java/com/WearWeather/wear/global/config/SecurityConfig.java
+++ b/src/main/java/com/WearWeather/wear/global/config/SecurityConfig.java
@@ -59,7 +59,7 @@ public class SecurityConfig {
             )
 
             .authorizeHttpRequests(authorizeHttpRequests -> authorizeHttpRequests
-                .requestMatchers("/auth/login", "/auth/reissue",
+                .requestMatchers("/auth/login", "/auth/reissue", "/location",
                     "/users/register", "/", "/oauth/kakao",
                     "/login/page", "/email/send-verification", "/email/verify-code").permitAll()
                 .requestMatchers(PathRequest.toH2Console()).permitAll()


### PR DESCRIPTION
## 개요
지역 데이터를 위해 행정구역 API를 이용하여 초기데이터를 설정한다.

## 기능
- 시군구 API를 사용하여 '광역시도'에 따른 시군구 데이터를 중복 제거하고, 정렬하여 데이터 저장 