### PR TITLE
지역 데이터 전달

### DIFF
--- a/src/main/java/com/WearWeather/wear/domain/location/controller/LocationController.java
+++ b/src/main/java/com/WearWeather/wear/domain/location/controller/LocationController.java
@@ -14,7 +14,7 @@ public class LocationController {
 
     @GetMapping("/location")
     public void getLocationDistrictData() throws Exception {
-        locationService.getLocationData();
+        locationService.saveLocationData();
     }
 
     @GetMapping("/regions")

--- a/src/main/java/com/WearWeather/wear/domain/location/controller/LocationController.java
+++ b/src/main/java/com/WearWeather/wear/domain/location/controller/LocationController.java
@@ -1,19 +1,26 @@
 package com.WearWeather.wear.domain.location.controller;
 
+import com.WearWeather.wear.domain.location.dto.response.RegionsResponse;
 import com.WearWeather.wear.domain.location.service.LocationService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("/location")
+@RequestMapping
 public class LocationController {
 
     private final LocationService locationService;
 
-    @GetMapping
+    @GetMapping("/location")
     public void getLocationDistrictData() throws Exception {
         locationService.getLocationData();
     }
+
+    @GetMapping("/regions")
+    public RegionsResponse getRegions(){
+        return locationService.getRegions();
+    }
+
 
 }

--- a/src/main/java/com/WearWeather/wear/domain/location/dto/response/DistrictResponse.java
+++ b/src/main/java/com/WearWeather/wear/domain/location/dto/response/DistrictResponse.java
@@ -1,0 +1,18 @@
+package com.WearWeather.wear.domain.location.dto.response;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record DistrictResponse(
+        Long districtId,
+        String districtName
+) {
+    public static DistrictResponse of(Long districtId, String districtName){
+        return DistrictResponse.builder()
+                .districtId(districtId)
+                .districtName(districtName)
+                .build();
+    }
+}

--- a/src/main/java/com/WearWeather/wear/domain/location/dto/response/RegionResponse.java
+++ b/src/main/java/com/WearWeather/wear/domain/location/dto/response/RegionResponse.java
@@ -1,0 +1,20 @@
+package com.WearWeather.wear.domain.location.dto.response;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record RegionResponse(
+        Long cityId,
+        String cityName,
+        List<DistrictResponse> district
+){
+    public static RegionResponse of(Long cityId, String cityName, List<DistrictResponse> district){
+        return RegionResponse.builder()
+                .cityId(cityId)
+                .cityName(cityName)
+                .district(district)
+                .build();
+    }
+}

--- a/src/main/java/com/WearWeather/wear/domain/location/dto/response/RegionsResponse.java
+++ b/src/main/java/com/WearWeather/wear/domain/location/dto/response/RegionsResponse.java
@@ -1,0 +1,17 @@
+package com.WearWeather.wear.domain.location.dto.response;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+
+public record RegionsResponse (
+        List<RegionResponse> region
+){
+    public static RegionsResponse of(List<RegionResponse> region){
+        return RegionsResponse.builder()
+                .region(region)
+                .build();
+    }
+}

--- a/src/main/java/com/WearWeather/wear/domain/location/service/LocationService.java
+++ b/src/main/java/com/WearWeather/wear/domain/location/service/LocationService.java
@@ -20,7 +20,7 @@ import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
-@Transactional
+@Transactional(readOnly = true)
 public class LocationService {
 
     @Value("${location.api.key}")
@@ -31,7 +31,8 @@ public class LocationService {
     private final RestTemplate restTemplate;
     ObjectMapper objectMapper = new ObjectMapper();
 
-    public void getLocationData() throws Exception  {
+    @Transactional
+    public void saveLocationData() throws Exception  {
 
         List<City> cityList = cityRepository.findAll();
 

--- a/src/main/java/com/WearWeather/wear/domain/location/service/LocationService.java
+++ b/src/main/java/com/WearWeather/wear/domain/location/service/LocationService.java
@@ -1,5 +1,8 @@
 package com.WearWeather.wear.domain.location.service;
 
+import com.WearWeather.wear.domain.location.dto.response.DistrictResponse;
+import com.WearWeather.wear.domain.location.dto.response.RegionResponse;
+import com.WearWeather.wear.domain.location.dto.response.RegionsResponse;
 import com.WearWeather.wear.domain.location.entity.City;
 import com.WearWeather.wear.domain.location.entity.District;
 import com.WearWeather.wear.domain.location.repository.CityRepository;
@@ -9,6 +12,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestTemplate;
 
 import java.util.*;
@@ -16,6 +20,7 @@ import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class LocationService {
 
     @Value("${location.api.key}")
@@ -68,5 +73,62 @@ public class LocationService {
                 districtRepository.saveAll(districtsToSave);
             }
         }
+    }
+
+    public RegionsResponse getRegions(){
+        List<City> cityList = cityRepository.findAll();
+        List<District> districts = districtRepository.findAll();
+        Map<Long, List<District>> districtMap = districts.stream()
+                .collect(Collectors.groupingBy(District::getCityId));
+
+        List<RegionResponse> regionResponse = getRegionResponseList(cityList, districtMap);
+
+        return RegionsResponse.of(regionResponse);
+    }
+
+    private List<RegionResponse> getRegionResponseList(List<City> cityList, Map<Long, List<District>> districtMap){
+
+        List<RegionResponse> regionResponse = new ArrayList<>();
+        regionResponse.add(setRegionInitialData());
+        regionResponse.addAll(getRegionResponseListByCity(cityList, districtMap));
+
+        return regionResponse;
+    }
+
+    private List<RegionResponse> getRegionResponseListByCity(List<City> cityList, Map<Long, List<District>> districtMap){
+        return cityList.stream()
+                .filter(city -> districtMap.containsKey(city.getId()))
+                .map(city -> getRegionResponseByCity(city, districtMap.get(city.getId())))
+                .toList();
+    }
+    private RegionResponse getRegionResponseByCity(City city, List<District> districts){
+
+        List<DistrictResponse> districtByCity = new ArrayList<>();
+        districtByCity.add(setDistrictInitialData());
+
+        districtByCity.addAll(getDistrictResponse(districts));
+
+        return RegionResponse.of(city.getId(), city.getCity(), districtByCity);
+    }
+
+    private List<DistrictResponse> getDistrictResponse(List<District> districts) {
+        return districts.stream()
+                .map(district -> DistrictResponse.of(district.getId(), district.getDistrict()))
+                .toList();
+    }
+
+    private RegionResponse setRegionInitialData(){
+        Long cityId = 1L;
+        String cityName = "전체";
+        List<DistrictResponse> emptyResponse = Collections.emptyList();
+
+        return RegionResponse.of(cityId, cityName, emptyResponse);
+    }
+
+    private DistrictResponse setDistrictInitialData(){
+        Long districtId = 0L;
+        String districtName = "전체";
+
+        return DistrictResponse.of(districtId, districtName);
     }
 }

--- a/src/main/java/com/WearWeather/wear/global/config/SecurityConfig.java
+++ b/src/main/java/com/WearWeather/wear/global/config/SecurityConfig.java
@@ -59,7 +59,7 @@ public class SecurityConfig {
             )
 
             .authorizeHttpRequests(authorizeHttpRequests -> authorizeHttpRequests
-                .requestMatchers("/auth/login", "/auth/reissue", "/location",
+                .requestMatchers("/auth/login", "/auth/reissue", "/location", "/regions",
                     "/users/register", "/", "/oauth/kakao",
                     "/login/page", "/email/send-verification", "/email/verify-code").permitAll()
                 .requestMatchers("/h2-console/**").permitAll()


### PR DESCRIPTION
## 개요
필터 검색을 위해 사용되는 지역데이터를 프론트엔드로 전달한다.

## 기능
전체 선택을 위한 '전체' 항목을 초기 데이터로 설정하고 
광역시도 / 시군구 로 구분하여 Response DTO를 반환한다.