### PR TITLE
프론트 서버에서 api 요청 시 Securing OPTIONS 문제 해결을 위한 수정

### DIFF
--- a/src/main/java/com/WearWeather/wear/global/config/SecurityConfig.java
+++ b/src/main/java/com/WearWeather/wear/global/config/SecurityConfig.java
@@ -4,9 +4,9 @@ package com.WearWeather.wear.global.config;
 import com.WearWeather.wear.global.jwt.TokenProvider;
 import com.WearWeather.wear.global.jwt.handler.JwtAccessDeniedHandler;
 import com.WearWeather.wear.global.jwt.handler.JwtAuthenticationEntryPoint;
-import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -59,6 +59,7 @@ public class SecurityConfig {
             )
 
             .authorizeHttpRequests(authorizeHttpRequests -> authorizeHttpRequests
+                .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                 .requestMatchers("/auth/login", "/auth/reissue", "/location", "/regions",
                     "/users/register", "/", "/oauth/kakao",
                     "/login/page", "/email/send-verification", "/email/verify-code").permitAll()


### PR DESCRIPTION
## 개요
- 프론트 서버에서 백엔드 서버 api 요청시 Securing OPTIONS 문제 발생
- CORS Preflight 요청
  - 브라우저는 서로 다른 도메인 간에 HTTP 요청을 보내기 전에 보안상의 이유로 OPTIONS 메서드를 사용하여 서버에 "이 요청을 허용할 수 있는지" 확인하는 preflight 요청을 보낸다. 이 요청은 인증 정보 없이 이루어진다.
- Spring Security와의 상호작용:
  - Spring Security는 기본적으로 모든 요청을 보호하려고 한다. 따라서, OPTIONS 요청도 인증이 필요한 요청으로 처리될 수 있다.
  - 만약 OPTIONS 요청이 인증 없이 처리되지 않으면, 브라우저는 CORS 정책 위반으로 간주하고 실제 요청(예: POST, GET 등)을 보내지 않게 된다.
- 문제 해결:
  - Spring Security에서 모든 OPTIONS 요청을 인증 없이 처리하도록 설정 추가
