### PR TITLE
프론트 Preflight 요청 처리 에러 수정

### DIFF
--- a/src/main/java/com/WearWeather/wear/global/config/CorsConfig.java
+++ b/src/main/java/com/WearWeather/wear/global/config/CorsConfig.java
@@ -18,7 +18,7 @@ public class CorsConfig {
         config.addAllowedHeader("*");
         config.addAllowedMethod("*");
 
-        source.registerCorsConfiguration("/api/**", config);
+        source.registerCorsConfiguration("/**", config);
         return new CorsFilter(source);
     }
 }


### PR DESCRIPTION
## 개요
프론트엔드의 OPTIONS 요청에 대한 에러 발생

## 과정
기존 SecurityConfig 내 filterChain() 메서드에 구현된 CORS 필터가 스프링 시큐리티의 사용자 인증 필터(UsernamePasswordAuthenticationFilter) 전에 처리되도록 설정되어 있다. 
따라서, CORS 필터가 먼저 실행되기 때문에, 현재 Preflight 요청 처리 실패는 스프링 시큐리티 filterChain()에서 발생하는 것이 아니다.
`
http
 .addFilterBefore(corsFilter, UsernamePasswordAuthenticationFilter.class)
`

CorsConfig 클래스의 corsFilter() 메서드에서 
application.properties에 설정한 context-path의 경로를 포함하여 인식하지 않아 `"/api/**"` 의 URL 패턴을 CORS 설정에 적용하지 못하였으므로 `"/**"` 으로 URL 패턴 수정하여 에러 수정하였다.
`source.registerCorsConfiguration("/**", config);`

### 테스트
postman으로 origin 헤더 추가한 후 테스트하였을 때
Access-Control-Allow-Origin 포함한 헤더가 함께 전송되는 것을 확인하였다.
<img width="653" alt="cors" src="https://github.com/user-attachments/assets/c1c31d66-0e9c-4fbf-8524-acc42f0fdd1a">





