### PR TITLE
RefreshToekn 관리 방식 수정

### DIFF
--- a/src/main/java/com/WearWeather/wear/domain/auth/dto/response/LoginResponse.java
+++ b/src/main/java/com/WearWeather/wear/domain/auth/dto/response/LoginResponse.java
@@ -18,17 +18,15 @@ public class LoginResponse {
     private final boolean isSocial;
     private final Set<Authority> authorities;
     private final String accessToken;
-    private final String refreshToken;
 
-    public static LoginResponse of(User user, String at, String rt) {
+    public static LoginResponse of(User user, String accessToken) {
         return LoginResponse.builder()
             .email(user.getEmail())
             .name(user.getName())
             .nickName(user.getNickname())
             .isSocial(user.isSocial())
             .authorities(user.getAuthorities())
-            .accessToken(at)
-            .refreshToken(rt)
+            .accessToken(accessToken)
             .build();
     }
 }

--- a/src/main/java/com/WearWeather/wear/domain/auth/dto/response/TokenResponse.java
+++ b/src/main/java/com/WearWeather/wear/domain/auth/dto/response/TokenResponse.java
@@ -12,5 +12,4 @@ import lombok.Getter;
 public class TokenResponse {
 
     private final String accessToken;
-    private final String refreshToken;
 }

--- a/src/main/java/com/WearWeather/wear/domain/location/service/LocationService.java
+++ b/src/main/java/com/WearWeather/wear/domain/location/service/LocationService.java
@@ -9,11 +9,19 @@ import com.WearWeather.wear.domain.location.entity.District;
 import com.WearWeather.wear.domain.location.repository.CityRepository;
 import com.WearWeather.wear.domain.location.repository.DistrictRepository;
 import com.WearWeather.wear.domain.post.dto.response.LocationResponse;
+import com.WearWeather.wear.domain.post.entity.Location;
 import com.WearWeather.wear.global.exception.CustomException;
 import com.WearWeather.wear.global.exception.ErrorCode;
-import com.WearWeather.wear.domain.post.entity.Location;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
@@ -26,16 +34,12 @@ import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.util.DefaultUriBuilderFactory;
 import reactor.core.publisher.Mono;
 
-import java.io.IOException;
-import java.util.*;
-import java.util.stream.Collectors;
-
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class LocationService {
 
-    @Value("${location.api.key}")
+    @Value("${location.api.consumer-key}")
     private String openApiKey;
 
     @Value("${kakao.geo.coord.base-url}")

--- a/src/main/java/com/WearWeather/wear/domain/location/service/LocationService.java
+++ b/src/main/java/com/WearWeather/wear/domain/location/service/LocationService.java
@@ -14,6 +14,7 @@ import com.WearWeather.wear.global.exception.CustomException;
 import com.WearWeather.wear.global.exception.ErrorCode;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.*;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;

--- a/src/main/java/com/WearWeather/wear/domain/oauth/controller/OAuthController.java
+++ b/src/main/java/com/WearWeather/wear/domain/oauth/controller/OAuthController.java
@@ -3,6 +3,9 @@ package com.WearWeather.wear.domain.oauth.controller;
 import com.WearWeather.wear.domain.auth.dto.response.LoginResponse;
 import com.WearWeather.wear.domain.oauth.infrastructure.kakao.KakaoLoginParam;
 import com.WearWeather.wear.domain.oauth.service.OAuthLoginService;
+import com.WearWeather.wear.global.jwt.TokenProvider;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -19,12 +22,21 @@ import org.springframework.web.bind.annotation.RestController;
 public class OAuthController {
 
     private final OAuthLoginService oAuthLoginService;
+    private final TokenProvider tokenProvider;
 
     @GetMapping("/kakao")
-    public ResponseEntity<LoginResponse> kakaoLogin(@RequestParam("code") String code) {
+    public ResponseEntity<LoginResponse> kakaoLogin(@RequestParam("code") String code, HttpServletResponse response) {
         KakaoLoginParam param = new KakaoLoginParam(code);
-        LoginResponse response = oAuthLoginService.login(param);
-        return new ResponseEntity<>(response, HttpStatus.OK);
-    }
+        LoginResponse loginResponse = oAuthLoginService.login(param);
 
+        String refreshToken = tokenProvider.renewRefreshToken(loginResponse.getAccessToken());
+        Cookie refreshTokenCookie = new Cookie("refreshToken", refreshToken);
+        refreshTokenCookie.setHttpOnly(true);
+        refreshTokenCookie.setSecure(true);
+        refreshTokenCookie.setPath("/");
+        refreshTokenCookie.setMaxAge(7 * 24 * 60 * 60);
+        response.addCookie(refreshTokenCookie);
+
+        return new ResponseEntity<>(loginResponse, HttpStatus.OK);
+    }
 }


### PR DESCRIPTION
## PR 개요
- 기존 방식 -> AT,RT 모두 발급 후 클라이언트에게 반환
  - 클라이언트 측에서 AT,RT 모두 관리하게 되었을 때, RT까지 외부 사용자에게 노출되는 위험이 있어서 보안 취약점이 발생할 수 있다. 

- 이에 따라 토큰 관리 방식에 있어서 보안 강화를 위해 클라이언트언트에게 AT,RT를 반환하는 기존 방식에서, AT만 반환하고 RT는 Http only 쿠키에 설정하여 전달하는 방식으로 리팩토링을 진행합니다.

## 주요 작업 내용
  - 클라이언트에게 발급된 AT를 반환하고, RT는 발급 후 Http only 쿠키로 설정하여 전달하는 방식으로 변경
  - 기존 AT,RT를 반환해주고 있던 로그인, 토큰 재발급 api에 대해 AT만 반환하도록 비즈니스 로직 수정
  -  단위 테스트 수정

