### PR TITLE
변경된 요구사항에 따른 게시글 생성,수정,삭제 리팩토링

### DIFF
--- a/src/main/java/com/WearWeather/wear/domain/post/dto/request/PostCreateRequest.java
+++ b/src/main/java/com/WearWeather/wear/domain/post/dto/request/PostCreateRequest.java
@@ -6,7 +6,6 @@ import com.WearWeather.wear.domain.postImage.dto.request.PostImageRequest;
 import com.WearWeather.wear.domain.tag.dto.TaggableRequest;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -28,8 +27,11 @@ public class PostCreateRequest implements PostImageRequest, TaggableRequest {
     @Size(max = 50)
     private final String content;
 
-    @Valid
-    private final Location location;
+    @NotBlank
+    private final String city;
+
+    @NotBlank
+    private final String district;
 
     @NotNull
     @Size(max = 2)
@@ -42,26 +44,28 @@ public class PostCreateRequest implements PostImageRequest, TaggableRequest {
     @NotNull
     private final Long seasonTagId;
 
-    private final List<Long> imageId = new ArrayList<>();
+    private final List<Long> imageIds = new ArrayList<>();
 
     @JsonCreator
     public PostCreateRequest(
         @JsonProperty("title") String title,
         @JsonProperty("content") String content,
-        @JsonProperty("location") Location location,
+        @JsonProperty("city") String city,
+        @JsonProperty("district") String district,
         @JsonProperty("weatherTagIds") Set<Long> weatherTagIds,
         @JsonProperty("temperatureTagIds") Set<Long> temperatureTagIds,
         @JsonProperty("seasonTagId") Long seasonTagId
     ) {
         this.title = title;
         this.content = content;
-        this.location = location;
+        this.city = city;
+        this.district = district;
         this.weatherTagIds = weatherTagIds;
         this.temperatureTagIds = temperatureTagIds;
         this.seasonTagId = seasonTagId;
     }
 
-    public Post toEntity(Long userId) {
+    public Post toEntity(Long userId,Location location) {
         return Post.builder()
             .userId(userId)
             .title(title)

--- a/src/main/java/com/WearWeather/wear/domain/post/dto/request/PostUpdateRequest.java
+++ b/src/main/java/com/WearWeather/wear/domain/post/dto/request/PostUpdateRequest.java
@@ -1,6 +1,5 @@
 package com.WearWeather.wear.domain.post.dto.request;
 
-import com.WearWeather.wear.domain.post.entity.Location;
 import com.WearWeather.wear.domain.postImage.dto.request.PostImageRequest;
 import com.WearWeather.wear.domain.tag.dto.TaggableRequest;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -26,7 +25,11 @@ public class PostUpdateRequest implements PostImageRequest, TaggableRequest {
     @Size(max = 50)
     private final String content;
 
-    private final Location location;
+    @NotBlank
+    private final String city;
+
+    @NotBlank
+    private final String district;
 
     @NotNull
     @Size(max = 2)
@@ -39,20 +42,22 @@ public class PostUpdateRequest implements PostImageRequest, TaggableRequest {
     @NotNull
     private final Long seasonTagId;
 
-    private final List<Long> imageId = new ArrayList<>();
+    private final List<Long> imageIds = new ArrayList<>();
 
     @JsonCreator
     public PostUpdateRequest(
         @JsonProperty("title") String title,
         @JsonProperty("content") String content,
-        @JsonProperty("location") Location location,
+        @JsonProperty("city") String city,
+        @JsonProperty("district") String district,
         @JsonProperty("weatherTagIds") Set<Long> weatherTagIds,
         @JsonProperty("temperatureTagIds") Set<Long> temperatureTagIds,
         @JsonProperty("seasonTagId") Long seasonTagId
     ) {
         this.title = title;
         this.content = content;
-        this.location = location;
+        this.city = city;
+        this.district = district;
         this.weatherTagIds = weatherTagIds;
         this.temperatureTagIds = temperatureTagIds;
         this.seasonTagId = seasonTagId;

--- a/src/main/java/com/WearWeather/wear/domain/post/entity/Post.java
+++ b/src/main/java/com/WearWeather/wear/domain/post/entity/Post.java
@@ -62,7 +62,7 @@ public class Post extends BaseTimeEntity implements Serializable {
         this.likeCount--;
     }
 
-    public void modifyPostAttributes(String title, String content, Location location) {
+    public void updatePostDetails(String title, String content, Location location) {
         this.title = title;
         this.content = content;
         this.location = location;

--- a/src/main/java/com/WearWeather/wear/domain/postHidden/repository/PostHiddenRepository.java
+++ b/src/main/java/com/WearWeather/wear/domain/postHidden/repository/PostHiddenRepository.java
@@ -1,12 +1,20 @@
 package com.WearWeather.wear.domain.postHidden.repository;
 
 import com.WearWeather.wear.domain.postHidden.entity.PostHidden;
+import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 public interface PostHiddenRepository extends JpaRepository<PostHidden, Long> {
 
     boolean existsByUserIdAndPostId(Long userId, Long postId);
+
     List<PostIdMapping> findAllByUserId(Long userId);
+
+    @Modifying
+    @Query("DELETE FROM PostHidden ph WHERE ph.postId = :postId")
+    void deleteByPostId(@Param("postId") Long postId);
 }

--- a/src/main/java/com/WearWeather/wear/domain/postHidden/service/PostHiddenService.java
+++ b/src/main/java/com/WearWeather/wear/domain/postHidden/service/PostHiddenService.java
@@ -44,4 +44,9 @@ public class PostHiddenService {
                 .map(PostIdMapping::getPostId)
                 .toList();
     }
+
+    @Transactional
+    public void deleteHiddenByPostId(Long postId) {
+        postHiddenRepository.deleteByPostId(postId);
+    }
 }

--- a/src/main/java/com/WearWeather/wear/domain/postImage/dto/request/PostImageRequest.java
+++ b/src/main/java/com/WearWeather/wear/domain/postImage/dto/request/PostImageRequest.java
@@ -4,5 +4,5 @@ import java.util.List;
 
 public interface PostImageRequest {
 
-    List<Long> getImageId();
+    List<Long> getImageIds();
 }

--- a/src/main/java/com/WearWeather/wear/domain/postImage/repository/PostImageRepository.java
+++ b/src/main/java/com/WearWeather/wear/domain/postImage/repository/PostImageRepository.java
@@ -1,8 +1,12 @@
 package com.WearWeather.wear.domain.postImage.repository;
 
 import com.WearWeather.wear.domain.postImage.entity.PostImage;
+import io.lettuce.core.dynamic.annotation.Param;
 import java.util.List;
+import java.util.Set;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -11,4 +15,10 @@ public interface PostImageRepository extends JpaRepository<PostImage, Long> {
     List<PostImage> findByPostId(Long postId);
 
     List<PostImage> findByIdIn(List<Long> ids);
-}
+
+    @Query("SELECT pi.id FROM PostImage pi WHERE pi.postId = :postId")
+    List<Long> findImageIdsByPostId(@Param("postId") Long postId);
+
+    @Modifying
+    @Query("DELETE FROM PostImage pi WHERE pi.postId = :postId")
+    void deleteByPostId(@Param("postId") Long postId);}

--- a/src/main/java/com/WearWeather/wear/domain/postLike/repository/LikeRepository.java
+++ b/src/main/java/com/WearWeather/wear/domain/postLike/repository/LikeRepository.java
@@ -4,9 +4,16 @@ import com.WearWeather.wear.domain.postLike.entity.Like;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 public interface LikeRepository extends JpaRepository<Like, Long>, LikeRepositoryCustom {
     Optional<Like> findByPostIdAndUserId(Long postId, Long userId);
 
     boolean existsByPostIdAndUserId(Long postId, Long userId);
+
+    @Modifying
+    @Query("DELETE FROM Like li WHERE li.postId = :postId")
+    void deleteByPostId(Long postId);
+
 }

--- a/src/main/java/com/WearWeather/wear/domain/postReport/repository/PostReportRepository.java
+++ b/src/main/java/com/WearWeather/wear/domain/postReport/repository/PostReportRepository.java
@@ -1,11 +1,19 @@
 package com.WearWeather.wear.domain.postReport.repository;
 
 import com.WearWeather.wear.domain.postReport.entity.PostReport;
+import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 public interface PostReportRepository extends JpaRepository<PostReport, Long> {
     boolean existsByUserIdAndPostId(Long userId, Long postId);
+
     Long countByPostId(long postId);
 
     boolean existsByPostId(Long postId);
+
+    @Modifying
+    @Query("DELETE FROM PostReport pr WHERE pr.postId = :postId")
+    void deleteByPostId(@Param("postId") Long postId);
 }

--- a/src/main/java/com/WearWeather/wear/domain/postReport/service/PostReportService.java
+++ b/src/main/java/com/WearWeather/wear/domain/postReport/service/PostReportService.java
@@ -50,4 +50,9 @@ public class PostReportService {
     public boolean hasReports(Long postId){
         return checkPostReported(postId) && hasExceededReportCount(postId);
     }
+
+    @Transactional
+    public void deleteReportByPostId(Long postId) {
+        postReportRepository.deleteByPostId(postId);
+    }
 }

--- a/src/main/java/com/WearWeather/wear/domain/postTag/repository/PostTagRepository.java
+++ b/src/main/java/com/WearWeather/wear/domain/postTag/repository/PostTagRepository.java
@@ -1,12 +1,16 @@
 package com.WearWeather.wear.domain.postTag.repository;
 
 import com.WearWeather.wear.domain.postTag.entity.PostTag;
+import io.lettuce.core.dynamic.annotation.Param;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 public interface PostTagRepository extends JpaRepository<PostTag, Long> {
 
     List<PostTag> findByPostId(Long postId);
 
-    void deleteByPostId(Long postId);
-}
+    @Modifying
+    @Query("DELETE FROM PostTag pt WHERE pt.postId = :postId")
+    void deleteByPostId(@Param("postId") Long postId);}

--- a/src/main/java/com/WearWeather/wear/domain/storage/controller/AwsS3Controller.java
+++ b/src/main/java/com/WearWeather/wear/domain/storage/controller/AwsS3Controller.java
@@ -31,7 +31,7 @@ public class AwsS3Controller {
 
     @DeleteMapping("/post-image/{imageId}")
     public ResponseEntity<Void> delete(@PathVariable Long imageId) {
-        postImageService.deletePostImage(imageId);
+        postImageService.deleteImage(imageId);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/WearWeather/wear/global/exception/ErrorCode.java
+++ b/src/main/java/com/WearWeather/wear/global/exception/ErrorCode.java
@@ -55,7 +55,7 @@ public enum ErrorCode {
     GEO_COORD_SERVER_ERROR(BAD_REQUEST,"서버 오류입니다."),
 
     UNAUTHORIZED_USER(UNAUTHORIZED,"게시글 수정 권한이 없습니다."),
-    IMAGE_ALREADY_USED(BAD_REQUEST, "이미 다른 게시글에 사용된 이미지ID가 있습니다.")
+    IMAGE_ALREADY_USED(BAD_REQUEST, "이미 다른 게시글에 사용된 이미지ID가 있습니다."),
       
     FAIL_SAVE_LOCATION_CITY(BAD_REQUEST, "광역시도 저장 오류입니다."),
     FAIL_SAVE_LOCATION_DISTRICT(BAD_REQUEST, "시군구 저장 오류입니다."),

--- a/src/main/java/com/WearWeather/wear/global/exception/ErrorCode.java
+++ b/src/main/java/com/WearWeather/wear/global/exception/ErrorCode.java
@@ -53,6 +53,9 @@ public enum ErrorCode {
     REPORT_POST_ALREADY_EXIST(BAD_REQUEST, "이미 신고한 게시글입니다."),
     INVALID_REQUEST_PARAMETER(BAD_REQUEST, "경도, 위도 값이 유효하지 않습니다."),
     GEO_COORD_SERVER_ERROR(BAD_REQUEST,"서버 오류입니다."),
+
+    UNAUTHORIZED_USER(UNAUTHORIZED,"게시글 수정 권한이 없습니다."),
+    IMAGE_ALREADY_USED(BAD_REQUEST, "이미 다른 게시글에 사용된 이미지ID가 있습니다.")
     ;
 
     private final HttpStatus httpStatus;


### PR DESCRIPTION
## PR 개요
- #61 
- 변경된 요구사항에 따라 게시글 생성,수정,삭제 리팩토링을 진행합니다.

## 주요 작업 내용
  - 게시글 생성, 수정 request 변경 : request 내에서 Long 타입으로 받던 city, district 값을 String 타입으로 받는 방식으로 수정
  - 위의 수정사항에 따른 비즈니스 로직 수정
  - 게시글 삭제 시에 Post와 관계가 있는 다른 테이블들에 대해서 해당 테이블들이 가지고 있는 postId를 모두 삭제하는 흐름을 직접 구현
    - 외래키가 설정되어있지 않기 때문

## 추후 개선사항
- 각각의 Service들이 너무 많은 의존을 하고 있기 때문에 코드가 복잡해지고 순환 참조 문제도 발생되고 있습니다.
- 이에 따라 전체적인 코드 구조 개선이 추후에 필요할 것 같습니다.
- 제가 알아본 바로는 Facade 패턴,  인터페이스 사용(ex ServiceImpl와 Service) , CRUD에 대한 클래스 분리 등의 방식이 있는 것 같습니다.