### PR TITLE
게시글 조회 시 태그 응답 형태 변경

### DIFF
--- a/src/main/java/com/WearWeather/wear/domain/post/dto/response/PostByLocationResponse.java
+++ b/src/main/java/com/WearWeather/wear/domain/post/dto/response/PostByLocationResponse.java
@@ -9,19 +9,19 @@ import java.util.Map;
 public record PostByLocationResponse(
         Long postId,
         String thumbnail,
-        Long seasonTagId,
-        List<Long> weatherTagIds,
-        List<Long> temperatureTagIds,
+        String seasonTag,
+        List<String> weatherTags,
+        List<String> temperatureTags,
         boolean likeByUser,
         boolean reportPost
 ) {
-    public static PostByLocationResponse of(Long postId, String url, Map<String, List<Long>> tags, boolean like, boolean report){
+    public static PostByLocationResponse of(Long postId, String url, Map<String, List<String>> tags, boolean like, boolean report){
         return PostByLocationResponse.builder()
                 .postId(postId)
                 .thumbnail(url)
-                .seasonTagId(tags.get("SEASON").get(0))
-                .weatherTagIds(tags.get("WEATHER"))
-                .temperatureTagIds(tags.get("TEMPERATURE"))
+                .seasonTag(tags.get("SEASON").get(0))
+                .weatherTags(tags.get("WEATHER"))
+                .temperatureTags(tags.get("TEMPERATURE"))
                 .likeByUser(like)
                 .reportPost(report)
                 .build();

--- a/src/main/java/com/WearWeather/wear/domain/post/dto/response/PostByMeResponse.java
+++ b/src/main/java/com/WearWeather/wear/domain/post/dto/response/PostByMeResponse.java
@@ -10,19 +10,19 @@ public record PostByMeResponse(
         Long postId,
         String thumbnail,
         LocationResponse location,
-        Long seasonTagId,
-        List<Long> weatherTagIds,
-        List<Long> temperatureTagIds,
+        String seasonTag,
+        List<String> weatherTags,
+        List<String> temperatureTags,
         boolean reportPost
 ) {
-    public static PostByMeResponse of(Long postId, String url, LocationResponse location, Map<String, List<Long>> tags, boolean report){
+    public static PostByMeResponse of(Long postId, String url, LocationResponse location, Map<String, List<String>> tags, boolean report){
         return PostByMeResponse.builder()
                 .postId(postId)
                 .thumbnail(url)
                 .location(location)
-                .seasonTagId(tags.get("SEASON").get(0))
-                .weatherTagIds(tags.get("WEATHER"))
-                .temperatureTagIds(tags.get("TEMPERATURE"))
+                .seasonTag(tags.get("SEASON").get(0))
+                .weatherTags(tags.get("WEATHER"))
+                .temperatureTags(tags.get("TEMPERATURE"))
                 .reportPost(report)
                 .build();
     }

--- a/src/main/java/com/WearWeather/wear/domain/post/dto/response/PostDetailResponse.java
+++ b/src/main/java/com/WearWeather/wear/domain/post/dto/response/PostDetailResponse.java
@@ -20,14 +20,14 @@ public class PostDetailResponse {
     private final String content;
     private final ImagesResponse images;
     private final LocationResponse location;
-    private final Long seasonTagId;
-    private final List<Long> weatherTagIds;
-    private final List<Long> temperatureTagIds;
+    private final String seasonTag;
+    private final List<String> weatherTags;
+    private final List<String> temperatureTags;
     private final boolean likeByUser;
     private final int likedCount;
     private final boolean reportPost;
 
-    public static PostDetailResponse of(String nickname, Post post, ImagesResponse images, LocationResponse location, Map<String, List<Long>> tags, boolean like, boolean report){
+    public static PostDetailResponse of(String nickname, Post post, ImagesResponse images, LocationResponse location, Map<String, List<String>> tags, boolean like, boolean report){
 
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd HH:mm");
         String formattedDateTime = post.getCreatedAt().format(formatter);
@@ -40,9 +40,9 @@ public class PostDetailResponse {
                 .location(location)
                 .likedCount(post.getLikeCount())
                 .images(images)
-                .seasonTagId(tags.get("SEASON").get(0))
-                .weatherTagIds(tags.get("WEATHER"))
-                .temperatureTagIds(tags.get("TEMPERATURE"))
+                .seasonTag(tags.get("SEASON").get(0))
+                .weatherTags(tags.get("WEATHER"))
+                .temperatureTags(tags.get("TEMPERATURE"))
                 .likeByUser(like)
                 .reportPost(report)
                 .build();

--- a/src/main/java/com/WearWeather/wear/domain/post/dto/response/SearchPostResponse.java
+++ b/src/main/java/com/WearWeather/wear/domain/post/dto/response/SearchPostResponse.java
@@ -14,20 +14,20 @@ public class SearchPostResponse {
     private final Long postId;
     private final String thumbnail;
     private final LocationResponse location;
-    private final Long seasonTagId;
-    private final List<Long> weatherTagIds;
-    private final List<Long> temperatureTagIds;
+    private final String seasonTag;
+    private final List<String> weatherTags;
+    private final List<String> temperatureTags;
     private final boolean likeByUser;
     private final boolean reportPost;
 
-    public static SearchPostResponse of(PostWithLocationName post, String url, Map<String, List<Long>> tags, boolean like, boolean report){
+    public static SearchPostResponse of(PostWithLocationName post, String url, Map<String, List<String>> tags, boolean like, boolean report){
         return SearchPostResponse.builder()
                 .postId(post.postId())
                 .thumbnail(url)
                 .location(LocationResponse.of(post.cityName(), post.districtName()))
-                .seasonTagId(tags.get("SEASON").get(0))
-                .weatherTagIds(tags.get("WEATHER"))
-                .temperatureTagIds(tags.get("TEMPERATURE"))
+                .seasonTag(tags.get("SEASON").get(0))
+                .weatherTags(tags.get("WEATHER"))
+                .temperatureTags(tags.get("TEMPERATURE"))
                 .likeByUser(like)
                 .reportPost(report)
                 .build();

--- a/src/main/java/com/WearWeather/wear/domain/post/dto/response/TopLikedPostResponse.java
+++ b/src/main/java/com/WearWeather/wear/domain/post/dto/response/TopLikedPostResponse.java
@@ -11,19 +11,19 @@ public record TopLikedPostResponse(
         Long postId,
         String thumbnail,
         LocationResponse location,
-        Long seasonTagId,
-        List<Long> weatherTagIds,
-        List<Long> temperatureTagIds,
+        String seasonTag,
+        List<String> weatherTags,
+        List<String> temperatureTags,
         boolean likeByUser
 ) {
-    public static TopLikedPostResponse of(Post post, String url, LocationResponse location, Map<String, List<Long>> tags, boolean like) {
+    public static TopLikedPostResponse of(Post post, String url, LocationResponse location, Map<String, List<String>> tags, boolean like) {
         return TopLikedPostResponse.builder()
             .postId(post.getId())
             .thumbnail(url)
             .location(location)
-            .seasonTagId(tags.get("SEASON").get(0))
-            .weatherTagIds(tags.get("WEATHER"))
-            .temperatureTagIds(tags.get("TEMPERATURE"))
+            .seasonTag(tags.get("SEASON").get(0))
+            .weatherTags(tags.get("WEATHER"))
+            .temperatureTags(tags.get("TEMPERATURE"))
             .likeByUser(like)
             .build();
     }

--- a/src/main/java/com/WearWeather/wear/domain/post/service/PostService.java
+++ b/src/main/java/com/WearWeather/wear/domain/post/service/PostService.java
@@ -171,7 +171,7 @@ public class PostService {
     public TopLikedPostResponse getTopLikedPost(Post post, Long userId) {
         String url = getImageUrl(post.getThumbnailImageId());
 
-        Map<String, List<Long>> tags = getTagsByPostId(post.getId());
+        Map<String, List<String>> tags = getTagsByPostId(post.getId());
         LocationResponse location = locationService.findCityIdAndDistrictId(post.getLocation().getCity(), post.getLocation().getDistrict());
         boolean like = checkLikeByPostAndUser(post.getId(), userId);
 
@@ -189,7 +189,7 @@ public class PostService {
         Post post = findById(postId);
         ImagesResponse imageUrlList = getImagesResponse(post.getId());
         LocationResponse location = locationService.findCityIdAndDistrictId(post.getLocation().getCity(), post.getLocation().getDistrict());
-        Map<String, List<Long>> tags = getTagsByPostId(post.getId());
+        Map<String, List<String>> tags = getTagsByPostId(post.getId());
 
         boolean like = checkLikeByPostAndUser(post.getId(), userId);
         boolean report = postReportService.hasReports(post.getId());
@@ -223,7 +223,7 @@ public class PostService {
         return awsS3Service.getUrl(postImage.getName());
     }
 
-    public Map<String, List<Long>> getTagsByPostId(Long postId) {
+    public Map<String, List<String>> getTagsByPostId(Long postId) {
         List<PostTag> postTags = postTagRepository.findByPostId(postId);
 
         List<Long> tagIds = postTags.stream()
@@ -235,7 +235,7 @@ public class PostService {
         return tags.stream()
             .collect(Collectors.groupingBy(
                 Tag::getCategory,
-                Collectors.mapping(Tag::getTagId, Collectors.toList())
+                Collectors.mapping(Tag::getContent, Collectors.toList())
             ));
     }
 
@@ -280,7 +280,7 @@ public class PostService {
 
     public PostByLocationResponse getPostByLocation(Post post, Long userId) {
         String url = getImageUrl(post.getThumbnailImageId());
-        Map<String, List<Long>> tags = getTagsByPostId(post.getId());
+        Map<String, List<String>> tags = getTagsByPostId(post.getId());
 
         boolean like = checkLikeByPostAndUser(post.getId(), userId);
         boolean report = postReportService.hasReports(post.getId());
@@ -321,7 +321,7 @@ public class PostService {
 
         String url = getImageUrl(post.thumbnailImageId());
 
-        Map<String, List<Long>> tags = getTagsByPostId(post.postId());
+        Map<String, List<String>> tags = getTagsByPostId(post.postId());
 
         boolean like = checkLikeByPostAndUser(post.postId(), userId);
 
@@ -354,7 +354,7 @@ public class PostService {
 
         String url = getImageUrl(post.getThumbnailImageId());
         LocationResponse location = locationService.findCityIdAndDistrictId(post.getLocation().getCity(), post.getLocation().getDistrict());
-        Map<String, List<Long>> tags = getTagsByPostId(post.getId());
+        Map<String, List<String>> tags = getTagsByPostId(post.getId());
 
         boolean report = postReportService.hasReports(post.getId());
 
@@ -381,7 +381,7 @@ public class PostService {
         String url = getImageUrl(post.getThumbnailImageId());
         LocationResponse location = locationService.findCityIdAndDistrictId(post.getLocation().getCity(), post.getLocation().getDistrict());
 
-        Map<String, List<Long>> tags = getTagsByPostId(post.getId());
+        Map<String, List<String>> tags = getTagsByPostId(post.getId());
 
         boolean like = checkLikeByPostAndUser(post.getId(), userId);
 

--- a/src/main/java/com/WearWeather/wear/domain/postLike/dto/response/LikedPostByMeResponse.java
+++ b/src/main/java/com/WearWeather/wear/domain/postLike/dto/response/LikedPostByMeResponse.java
@@ -12,20 +12,20 @@ public record LikedPostByMeResponse(
         Long postId,
         String thumbnail,
         LocationResponse location,
-        Long seasonTagId,
-        List<Long> weatherTagIds,
-        List<Long> temperatureTagIds,
+        String seasonTag,
+        List<String> weatherTags,
+        List<String> temperatureTags,
         boolean likeByUser,
         boolean reportPost
 ) {
-    public static LikedPostByMeResponse of(Long postId, String url, LocationResponse location, Map<String, List<Long>> tags, boolean likeByUser, boolean report){
+    public static LikedPostByMeResponse of(Long postId, String url, LocationResponse location, Map<String, List<String>> tags, boolean likeByUser, boolean report){
         return LikedPostByMeResponse.builder()
                 .postId(postId)
                 .thumbnail(url)
                 .location(location)
-                .seasonTagId(tags.get("SEASON").get(0))
-                .weatherTagIds(tags.get("WEATHER"))
-                .temperatureTagIds(tags.get("TEMPERATURE"))
+                .seasonTag(tags.get("SEASON").get(0))
+                .weatherTags(tags.get("WEATHER"))
+                .temperatureTags(tags.get("TEMPERATURE"))
                 .likeByUser(likeByUser)
                 .reportPost(report)
                 .build();

--- a/src/main/java/com/WearWeather/wear/domain/tag/entity/Tag.java
+++ b/src/main/java/com/WearWeather/wear/domain/tag/entity/Tag.java
@@ -25,12 +25,16 @@ public class Tag {
     @Column(name = "category", nullable = false)
     private String category;
 
-    @Column(name = "content", length = 100, nullable = false)
+    @Column(name = "code", nullable = false)
+    private String code;
+
+    @Column(name = "content", nullable = false)
     private String content;
 
     @Builder
-    public Tag(String category, String content) {
+    public Tag(String category, String code, String content) {
         this.category = category;
+        this.code = code;
         this.content = content;
     }
 }


### PR DESCRIPTION
## 주요 사항
기존: 태그 Id Long 값을 받아 프론트엔드에서 문자열로 변환하여 화면에 표시함.
변경: 태그 값을 문자열로 반환하여 바로 화면에 표시하도록 변경함.

=>태그를 문자열로 반환함으로써 프론트엔드 로직을 단순화하고,
응답 데이터의 형식이 일관되어 클라이언트 측에서 데이터 처리와 파싱이 용이함.