### PR TITLE
게시글 이미지 필드 유효성 강화 및 불필요한 이미지 자동 삭제하는 스케줄러 추가

### DIFF
--- a/src/main/java/com/WearWeather/wear/domain/post/dto/request/PostCreateRequest.java
+++ b/src/main/java/com/WearWeather/wear/domain/post/dto/request/PostCreateRequest.java
@@ -7,6 +7,7 @@ import com.WearWeather.wear.domain.tag.dto.TaggableRequest;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.util.ArrayList;
@@ -44,6 +45,7 @@ public class PostCreateRequest implements PostImageRequest, TaggableRequest {
     @NotNull
     private final Long seasonTagId;
 
+    @NotEmpty(message = "이미지 업로드는 필수입니다.")
     private final List<Long> imageIds = new ArrayList<>();
 
     @JsonCreator

--- a/src/main/java/com/WearWeather/wear/domain/post/dto/request/PostUpdateRequest.java
+++ b/src/main/java/com/WearWeather/wear/domain/post/dto/request/PostUpdateRequest.java
@@ -5,6 +5,7 @@ import com.WearWeather.wear.domain.tag.dto.TaggableRequest;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.util.ArrayList;
@@ -42,6 +43,7 @@ public class PostUpdateRequest implements PostImageRequest, TaggableRequest {
     @NotNull
     private final Long seasonTagId;
 
+    @NotEmpty(message = "이미지 업로드는 필수입니다.")
     private final List<Long> imageIds = new ArrayList<>();
 
     @JsonCreator

--- a/src/main/java/com/WearWeather/wear/domain/postImage/repository/PostImageRepository.java
+++ b/src/main/java/com/WearWeather/wear/domain/postImage/repository/PostImageRepository.java
@@ -21,4 +21,8 @@ public interface PostImageRepository extends JpaRepository<PostImage, Long> {
 
     @Modifying
     @Query("DELETE FROM PostImage pi WHERE pi.postId = :postId")
-    void deleteByPostId(@Param("postId") Long postId);}
+    void deleteByPostId(@Param("postId") Long postId);
+
+    List<PostImage> findByPostIdIsNull();
+}
+

--- a/src/main/java/com/WearWeather/wear/domain/postImage/scheduler/postImageScheduler.java
+++ b/src/main/java/com/WearWeather/wear/domain/postImage/scheduler/postImageScheduler.java
@@ -1,0 +1,24 @@
+package com.WearWeather.wear.domain.postImage.scheduler;
+
+import com.WearWeather.wear.domain.postImage.service.PostImageService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@EnableScheduling
+@Component
+@RequiredArgsConstructor
+public class postImageScheduler {
+
+    private final PostImageService postImageService;
+
+    @Scheduled(cron = "${schedule.cron}")
+    public void runDeleteNecessaryImages() {
+        postImageService.deleteUnNecessaryImage();
+        log.info("Delete necessary images");
+
+    }
+}

--- a/src/main/java/com/WearWeather/wear/domain/postImage/scheduler/postImageScheduler.java
+++ b/src/main/java/com/WearWeather/wear/domain/postImage/scheduler/postImageScheduler.java
@@ -15,7 +15,7 @@ public class postImageScheduler {
 
     private final PostImageService postImageService;
 
-    @Scheduled(cron = "${schedule.cron}")
+    @Scheduled(cron = "0 0 3  * * ?")
     public void runDeleteNecessaryImages() {
         postImageService.deleteUnNecessaryImage();
         log.info("Delete necessary images");

--- a/src/main/java/com/WearWeather/wear/domain/user/entity/User.java
+++ b/src/main/java/com/WearWeather/wear/domain/user/entity/User.java
@@ -50,6 +50,10 @@ public class User extends BaseTimeEntity implements Serializable {
     @Column(name = "is_social", nullable = false)
     private boolean isSocial;
 
+    @Builder.Default
+    @Column(name = "is_delete", nullable = false)
+    private boolean isDelete = false;
+
     @ManyToMany
     @JoinTable(
         name = "user_authority",
@@ -59,6 +63,7 @@ public class User extends BaseTimeEntity implements Serializable {
 
     public void isRegularLogin() {
         this.isSocial = false;
+        this.isDelete = false;
     }
 
     public void isSocialLogin() {

--- a/src/main/java/com/WearWeather/wear/global/exception/ErrorCode.java
+++ b/src/main/java/com/WearWeather/wear/global/exception/ErrorCode.java
@@ -37,6 +37,7 @@ public enum ErrorCode {
     SERVER_ERROR(BAD_REQUEST, "이미지 업로드 실패"),
     INVALID_IMAGE_IMAGE(BAD_REQUEST, "이미지 파일이 유효하지 않습니다"),
     IMAGE_NOT_FOUND(NOT_FOUND, "이미지를 찾을 수 없습니다."),
+    USED_IMAGE_IN_DIFFERENT_POST(BAD_REQUEST,"다른 게시글에서 사용되고 있는 이미지 ID가 있습니다. 이미지를 다시 업로드 해주세요"),
 
     NOT_EXIST_POST(BAD_REQUEST, "존재하지 않는 게시글입니다."),
     ALREADY_LIKED_POST(BAD_REQUEST, "이미 좋아요된 게시글입니다."),


### PR DESCRIPTION
## PR 개요
아래와 같은 문제들이 발생하여 코드 수정을 진행합니다.
- 게시글 생성, 수정 시에 이미지id 필드가 null값으로 요청이 들어올 때 저장이 되는 문제
- 게시글ID와 매핑되지 않은 이미지 정보들이 DB에 그대로 남아있는 문제

## 주요 작업 내용
- 게시글 생성, 수정 Request 내에 imageIds 필드가 null 값을 허용하지 않도록 수정
- 게시글과 연관있는 이미지 맵핑 로직에 대한 유효성 검사 추가
- PostId와 매핑되지 않은, 즉 사용되지 않는 불필요한 이미지들이 주기적으로 삭제되는 스케줄러 추가
  - 해당 스케줄러는 24시간 이상 PostId와 매핑되지 않은 이미지를 대상으로 삭제 작업 수행
