### PR TITLE
토큰 재발급 api 요청 받는 방식 수정

### DIFF
--- a/src/main/java/com/WearWeather/wear/global/exception/ErrorCode.java
+++ b/src/main/java/com/WearWeather/wear/global/exception/ErrorCode.java
@@ -67,6 +67,9 @@ public enum ErrorCode {
     FAIL_SAVE_LOCATION_CITY(BAD_REQUEST, "광역시도 저장 오류입니다."),
     FAIL_SAVE_LOCATION_DISTRICT(BAD_REQUEST, "시군구 저장 오류입니다."),
     FAIL_CREATE_LOCATION_ACCESS_TOKEN(BAD_REQUEST, "위치 액세스 토큰 생성 오류입니다.."),
+
+    NOT_FOUND_COOKIE(NOT_FOUND,"인증 쿠키가 존재하지 않습니다. 다시 로그인 해주세요."),
+    NOT_FOUND_REFRESH_TOKEN_IN_COOKIE(NOT_FOUND,"쿠키에 리프레시 토큰이 존재하지 않습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/WearWeather/wear/global/jwt/TokenProvider.java
+++ b/src/main/java/com/WearWeather/wear/global/jwt/TokenProvider.java
@@ -105,7 +105,8 @@ public class TokenProvider implements InitializingBean {
             .signWith(key, SignatureAlgorithm.HS512)
             .compact();
 
-        redisService.setValues(String.valueOf(userId), refreshToken);
+        Long expirationInSeconds = this.refreshTokenValidityInMilliseconds / 1000;
+        redisService.setValues(String.valueOf(userId), refreshToken, expirationInSeconds);
 
         return refreshToken;
     }

--- a/src/main/java/com/WearWeather/wear/global/redis/RedisService.java
+++ b/src/main/java/com/WearWeather/wear/global/redis/RedisService.java
@@ -14,8 +14,8 @@ public class RedisService {
 
     private final RedisDao redisDao;
 
-    public Boolean setValues(String key, String value) {
-        redisDao.setValues(key, value);
+    public Boolean setValues(String key, String value, Long expirationInSeconds) {
+        redisDao.setValues(key, value,Duration.ofMillis(expirationInSeconds));
         return true;
     }
 


### PR DESCRIPTION
## PR 개요
- 토큰 재발급 시에 프론트에서 AT,RT를 받아오는 방식이 아닌 서버에서 관리되는 HTTP only cookie에서 RT 정보를 가져오도록 수정합니다.

## 주요 작업 내용
- 서버에서 관리되는 쿠키에서 RT 정보 가져오도록 수정