### PR TITLE
CORS 설정 수정

### DIFF
--- a/src/main/java/com/WearWeather/wear/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/WearWeather/wear/domain/auth/controller/AuthController.java
@@ -42,7 +42,7 @@ public class AuthController {
         String refreshToken = tokenProvider.renewRefreshToken(loginResponse.getAccessToken());
         Cookie refreshTokenCookie = new Cookie("refreshToken", refreshToken);
         refreshTokenCookie.setHttpOnly(true);
-        refreshTokenCookie.setSecure(true);
+        refreshTokenCookie.setSecure(false); // 백,프론트 서버 모두 https여야 해당 보안 설정 사용 가능
         refreshTokenCookie.setPath("/");
         refreshTokenCookie.setMaxAge(7 * 24 * 60 * 60);
         response.addCookie(refreshTokenCookie);

--- a/src/main/java/com/WearWeather/wear/global/config/CorsConfig.java
+++ b/src/main/java/com/WearWeather/wear/global/config/CorsConfig.java
@@ -1,5 +1,7 @@
 package com.WearWeather.wear.global.config;
 
+import java.util.Arrays;
+import java.util.List;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.cors.CorsConfiguration;
@@ -13,10 +15,11 @@ public class CorsConfig {
     public CorsFilter corsFilter() {
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         CorsConfiguration config = new CorsConfiguration();
+        config.setAllowedOrigins(List.of(
+            "http://localhost:3000"));
+        config.setAllowedMethods(Arrays.asList("GET", "POST", "OPTIONS", "PUT", "PATCH", "DELETE"));
+        config.setAllowedHeaders(List.of("*"));
         config.setAllowCredentials(true);
-        config.addAllowedOriginPattern("*");
-        config.addAllowedHeader("*");
-        config.addAllowedMethod("*");
 
         source.registerCorsConfiguration("/**", config);
         return new CorsFilter(source);

--- a/src/main/java/com/WearWeather/wear/global/config/CorsConfig.java
+++ b/src/main/java/com/WearWeather/wear/global/config/CorsConfig.java
@@ -16,7 +16,7 @@ public class CorsConfig {
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         CorsConfiguration config = new CorsConfiguration();
         config.setAllowedOrigins(List.of(
-            "http://localhost:3000"));
+            "http://localhost:3000","http://localhost:5173"));
         config.setAllowedMethods(Arrays.asList("GET", "POST", "OPTIONS", "PUT", "PATCH", "DELETE"));
         config.setAllowedHeaders(List.of("*"));
         config.setAllowCredentials(true);


### PR DESCRIPTION
## PR 개요
- 프론트와 쿠키를 주고받는 과정에 있어서 오류가 발생하여 2가지의 문제점을 해결합니다.
- 현재 로그인 시 발급된 RT를 쿠키로 설정할 때 보안을 위해 Httponly(true),secure(true)로 설정이 되어있음

**1. 프론트, 백엔드 서버 모두 http로 설정되어있음**
  - 문제 : secure는 보안을 위해 Https 외에는 쿠키를 전송하지 않도록 설정되어있음
  - 해결 방법 
    - 1) 프론트,백엔드 서버 모두 https로 설정
    - 2) secure 임시 false로 수정
  - -> 현재 원활한 작업을 위해 임시 false로 수정 후 작업 완료되면 https로 설정하는 작업 수행

 **2. CorsConfig는 AllowedOrigins,AllowedMethods,AllowedHeaders 가 ("*") 모두 허용되도록 설정이 되어있음**
  - 문제 : 인증을 위한 쿠키나헤더는 확실한 출처가 설정되어있어야 한다.
  - 해결 방법 : 확실한 출처로 변경
## 주요 작업 내용
- Cors 설정 수정
- secure(false)로 수정