### PR TITLE
AccessToken 재발급 시 발생하는 에러 수정

### DIFF
--- a/src/main/java/com/WearWeather/wear/domain/auth/service/AuthService.java
+++ b/src/main/java/com/WearWeather/wear/domain/auth/service/AuthService.java
@@ -11,10 +11,12 @@ import com.WearWeather.wear.global.exception.ErrorCode;
 import com.WearWeather.wear.global.jwt.TokenProvider;
 import com.WearWeather.wear.global.redis.RedisService;
 import java.util.Collections;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -49,7 +51,15 @@ public class AuthService {
 
         validateRefreshToken(userId, refreshToken);
 
-        Authentication authentication = new UsernamePasswordAuthenticationToken(userId, null, Collections.emptyList());
+        User user = userService.getUser(userId);
+        Authentication authentication = new UsernamePasswordAuthenticationToken(
+            userId,
+            null,
+            user.getAuthorities().stream()
+                .map(authority -> new SimpleGrantedAuthority(authority.getAuthorityName()))
+                .collect(Collectors.toList())
+        );
+
         String newAccessToken = tokenProvider.createAccessToken(authentication);
         return new TokenResponse(newAccessToken);
     }

--- a/src/test/java/com/WearWeather/wear/fixture/UserFixture.java
+++ b/src/test/java/com/WearWeather/wear/fixture/UserFixture.java
@@ -1,7 +1,9 @@
 package com.WearWeather.wear.fixture;
 
 import com.WearWeather.wear.domain.user.dto.request.RegisterUserRequest;
+import com.WearWeather.wear.domain.user.entity.Authority;
 import com.WearWeather.wear.domain.user.entity.User;
+import java.util.Collections;
 
 public class UserFixture {
 
@@ -35,5 +37,21 @@ public class UserFixture {
 
         return new RegisterUserRequest(email, password, name, nickname, isSocial);
 
+    }
+
+    public static User createUserWithAuthority(String authorityName) {
+        Authority authority = Authority.builder()
+            .authorityName(authorityName)
+            .build();
+
+        return User.builder()
+            .userId(userId)
+            .email(email)
+            .password(encodedPassword)
+            .name(name)
+            .nickname(nickname)
+            .isSocial(isSocial)
+            .authorities(Collections.singleton(authority))
+            .build();
     }
 }


### PR DESCRIPTION
## PR 개요
- 토큰 생성 시 유저 권한 정보가 토큰안에 비어있는 상태로 반환되어 "A granted authority textual representation is required" 에러가 뜨고 있어. 해당 문제를 해결합니다. 

## 주요 작업 내용
- 토큰 재발급 시에 해당 User의 Authority를 인증 객체 authentication에 추가하여 authority null로 반환되는 문제 해결
