### PR TITLE
게시글 등록 api 반환 정보 수정

### DIFF
--- a/src/main/java/com/WearWeather/wear/domain/post/controller/PostController.java
+++ b/src/main/java/com/WearWeather/wear/domain/post/controller/PostController.java
@@ -3,6 +3,7 @@ package com.WearWeather.wear.domain.post.controller;
 import com.WearWeather.wear.domain.post.dto.request.PostCreateRequest;
 import com.WearWeather.wear.domain.post.dto.request.PostUpdateRequest;
 import com.WearWeather.wear.domain.post.dto.request.PostsByFiltersRequest;
+import com.WearWeather.wear.domain.post.dto.response.PostCreateResponse;
 import com.WearWeather.wear.domain.post.dto.response.PostDetailResponse;
 import com.WearWeather.wear.domain.post.dto.response.PostsByFiltersResponse;
 import com.WearWeather.wear.domain.post.dto.response.PostsByLocationResponse;
@@ -36,9 +37,9 @@ public class PostController {
     private final PostService postService;
 
     @PostMapping
-    public ResponseEntity<ResponseCommonDTO> createPost(@LoggedInUser Long userId, @RequestBody @Valid PostCreateRequest request) {
+    public ResponseEntity<PostCreateResponse> createPost(@LoggedInUser Long userId, @RequestBody @Valid PostCreateRequest request) {
         Long postId = postService.createPost(userId, request);
-        return ResponseEntity.ok(new ResponseCommonDTO(true, ResponseMessage.SUCCESS_POST));
+        return ResponseEntity.ok(new PostCreateResponse(postId));
     }
 
     @GetMapping("/top-liked")

--- a/src/main/java/com/WearWeather/wear/domain/post/dto/response/PostCreateResponse.java
+++ b/src/main/java/com/WearWeather/wear/domain/post/dto/response/PostCreateResponse.java
@@ -1,0 +1,11 @@
+package com.WearWeather.wear.domain.post.dto.response;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public class PostCreateResponse {
+
+    private final Long postId;
+}


### PR DESCRIPTION
## PR 개요
- 프론트에서 UX 개선을 위해 게시글 등록 후 게시글ID를 반환하도록 수정합니다.

## 주요 작업 내용
- 게시글 등록 api요청 시 게시글ID 반환하도록 수정
