### PR TITLE
탈퇴한 사용자 조회 수정

### DIFF
--- a/src/main/java/com/WearWeather/wear/domain/user/service/UserService.java
+++ b/src/main/java/com/WearWeather/wear/domain/user/service/UserService.java
@@ -11,6 +11,7 @@ import com.WearWeather.wear.domain.user.dto.response.UserIdForPasswordUpdateResp
 import com.WearWeather.wear.domain.user.dto.response.UserInfoResponse;
 import com.WearWeather.wear.domain.user.enums.DeleteReason;
 import com.WearWeather.wear.domain.user.entity.User;
+import com.WearWeather.wear.domain.user.repository.UserNicknameMapping;
 import com.WearWeather.wear.domain.user.repository.UserRepository;
 import com.WearWeather.wear.global.exception.CustomException;
 import com.WearWeather.wear.global.exception.ErrorCode;
@@ -135,8 +136,8 @@ public class UserService {
 
     public String getNicknameById(Long userId) {
         return userRepository.findNicknameByUserIdAndIsDeleteFalse(userId)
-            .orElseThrow(() -> new CustomException(ErrorCode.NOT_EXIST_USER))
-            .getNickname();
+            .map(UserNicknameMapping::getNickname)
+            .orElse("탈퇴한 사용자");
     }
 
     @Transactional


### PR DESCRIPTION
## 개요
현재 탈퇴한 사용자의 게시글 조회 불가하므로
탈퇴한 사용자의 게시글은 닉네임을 탈퇴한 사용자로 설정하고 게시글은 조회할 수 있도록 함