### PR TITLE
필터 검색 오류 수정

### DIFF
--- a/src/main/java/com/WearWeather/wear/domain/post/repository/PostByFilterRepositoryCustomImpl.java
+++ b/src/main/java/com/WearWeather/wear/domain/post/repository/PostByFilterRepositoryCustomImpl.java
@@ -13,10 +13,8 @@ import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
-import com.querydsl.core.types.dsl.Expressions;
-import com.querydsl.core.types.dsl.NumberPath;
-import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -24,226 +22,132 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.support.PageableExecutionUtils;
 
-import java.util.List;
-
 @Slf4j
 @RequiredArgsConstructor
-public class PostByFilterRepositoryCustomImpl implements PostByFilterRepositoryCustom {
-    private final JPAQueryFactory jpaQueryFactory;
+public class PostByFilterRepositoryCustomImpl implements PostByFilterRepositoryCustom{
+  private final JPAQueryFactory jpaQueryFactory;
 
-    QPost qPost = QPost.post;
-    QPostTag qPostTag = QPostTag.postTag;
-    QCity qCity = QCity.city1;
-    QDistrict qDistrict = QDistrict.district1;
+  QPost qPost = QPost.post;
+  QPostTag qPostTag = QPostTag.postTag;
+  QCity qCity = QCity.city1;
+  QDistrict qDistrict = QDistrict.district1;
 
-    BooleanBuilder tagConditions = new BooleanBuilder();
-    BooleanBuilder havingConditions = new BooleanBuilder();
+  @Override
+  public Page<PostWithLocationName> findPostsByFilters (
+      PostsByFiltersRequest request, Pageable pageable, List<Long> hiddenPostIds) {
+    BooleanBuilder conditions = new BooleanBuilder();
 
-    @Override
-    public Page<PostWithLocationName> findPostsByFilters(PostsByFiltersRequest request, Pageable pageable, List<Long> invisiblePostIdsList) {
+    // 태그 조건 추가
+    addTagConditions(request, conditions);
 
-        List<Long> postIdsByLocation = findPostIdByLocationFilter(request);
-        List<Long> postIdsByTag = findPostIdByTagFilter(request);
+    // 위치 조건 추가
+    addLocationConditions(request, conditions);
 
-        log.info( " postIdByLocation = {}", postIdsByLocation.toString() );
-        log.info( " postIdsByTag = {}", postIdsByTag.toString() );
-
-        List<PostWithLocationName> posts = getQueryByFilters(postIdsByLocation, postIdsByTag, pageable, invisiblePostIdsList);
-        JPAQuery<Long> postsQueryCount = getPostsQueryCount(postIdsByLocation, postIdsByTag, invisiblePostIdsList);
-
-        return PageableExecutionUtils.getPage(posts, pageable, postsQueryCount::fetchOne);
-
+    // 숨겨진 포스트 조건 추가
+    if (!hiddenPostIds.isEmpty()) {
+      conditions.and(qPost.id.notIn(hiddenPostIds));
     }
 
-    public List<Long> findPostIdByTagFilter(PostsByFiltersRequest request){
+    List<PostWithLocationName> posts = jpaQueryFactory
+        .select(Projections.constructor(PostWithLocationName.class,
+            qPost.id.as("postId"),
+            qPost.thumbnailImageId.as("thumbnailImageId"),
+            qCity.city.as("cityName"),
+            qDistrict.district.as("districtName")))
+        .from(qPost)
+        .leftJoin(qCity).on(qPost.location.city.eq(qCity.id))
+        .leftJoin(qDistrict).on(qPost.location.district.eq(qDistrict.id))
+        .where(conditions)
+        .offset(pageable.getOffset())
+        .limit(pageable.getPageSize())
+        .orderBy(getSortColumn(pageable.getSort()))
+        .fetch();
 
-        List<Long> seasonTagIds = request.getSeasonTagIds();
-        List<Long> weatherTagIds = request.getWeatherTagIds();
-        List<Long> temperatureTagIds = request.getTemperatureTagIds();
+    long totalCount = jpaQueryFactory
+        .select(qPost.count())
+        .from(qPost)
+        .where(conditions)
+        .fetchOne();
 
-        log.info( " seasonTagIds = {}", seasonTagIds.toString() );
-        log.info( " weatherTagIds = {}", weatherTagIds.toString() );
-        log.info( " temperatureTagIds = {}", temperatureTagIds.toString() );
+    return PageableExecutionUtils.getPage(posts, pageable, () -> totalCount);
+  }
 
-        JPAQuery<Long> postIdByTagFilter = jpaQueryFactory.select(qPostTag.postId)
-                .from(qPostTag)
-                .groupBy(qPostTag.postId);
+  private void addTagConditions(PostsByFiltersRequest request, BooleanBuilder conditions) {
+    List<Long> seasonTagIds = request.getSeasonTagIds();
+    List<Long> weatherTagIds = request.getWeatherTagIds();
+    List<Long> temperatureTagIds = request.getTemperatureTagIds();
 
-        BooleanExpression seasonTagCondition = createTagCondition(qPostTag, seasonTagIds);
-        createWhereAndHavingCondition(seasonTagCondition, seasonTagIds);
+    if (!seasonTagIds.isEmpty()) {
+      conditions.or(qPostTag.tagId.in(seasonTagIds));
+    }
+    if (!weatherTagIds.isEmpty()) {
+      conditions.or(qPostTag.tagId.in(weatherTagIds));
+    }
+    if (!temperatureTagIds.isEmpty()) {
+      conditions.or(qPostTag.tagId.in(temperatureTagIds));
+    }
+  }
 
-        BooleanExpression weatherTagCondition = createTagCondition(qPostTag, weatherTagIds);
-        createWhereAndHavingCondition(weatherTagCondition, weatherTagIds);
+  private void addLocationConditions(PostsByFiltersRequest request, BooleanBuilder conditions) {
+    List<Location> locationList = request.getLocationList().stream()
+        .map(LocationRequest::toEntity)
+        .toList();
 
-        BooleanExpression temperatureTagCondition = createTagCondition(qPostTag, temperatureTagIds);
-        createWhereAndHavingCondition(temperatureTagCondition, temperatureTagIds);
+    if (!locationList.isEmpty()) {
+      conditions.and(checkSearchAllDistrictInCity(locationList));
+    }
+  }
 
-        if(tagConditions.hasValue()){
-            postIdByTagFilter.where(tagConditions);
+  private OrderSpecifier<?> getSortColumn(Sort sort){
 
-            log.info("tagConditions has value");
-        }
-
-        if(havingConditions.hasValue()){
-            postIdByTagFilter.having(havingConditions);
-
-            log.info("havingConditions has value");
-
-        }
-
-        return postIdByTagFilter.fetch();
+    if (sort == null || sort.isEmpty()) {
+      return new OrderSpecifier<>(Order.DESC, qPost.createdAt); //기본 정렬
     }
 
-    public List<Long> findPostIdByLocationFilter(PostsByFiltersRequest request) {
+    Sort.Order order = sort.iterator().next();
+    String sortColumn = order.getProperty();
+    Order direction = order.getDirection() == Sort.Direction.ASC ? Order.ASC : Order.DESC;
 
-        List<Location> locationList = request.getLocationList().stream()
-                .map(LocationRequest::toEntity)
-                .toList();
+    return switch (sortColumn) {
+      case "createdAt" -> new OrderSpecifier<>(direction, qPost.createdAt);
+      case "likeCount" -> new OrderSpecifier<>(direction, qPost.likeCount);
+      default -> new OrderSpecifier<>(Order.DESC, qPost.createdAt);
+    };
+  }
 
-        JPAQuery<Long> postIdByLocationFilter = jpaQueryFactory
-                .select(qPost.id)
-                .from(qPost);
+  private BooleanExpression checkSearchAllDistrictInCity(List<Location> locationList){
+    Long districtEntireValue = 0L;
 
-        if (!locationList.isEmpty()) {
+    boolean hasDistrictEntireValue = locationList.stream()
+        .anyMatch(location -> location.getDistrict().equals(districtEntireValue));
 
-            boolean hasCityEntireValue = checkSearchAllCity(locationList);
+    if (hasDistrictEntireValue) {
+      List<Long> city = extractCityListForEntireDistrict(locationList, districtEntireValue);
+      List<Location> otherCityList = extractCityListForOtherDistrict(locationList, districtEntireValue);
 
-            if (!hasCityEntireValue) {
-                BooleanExpression locationTagCondition = checkSearchAllDistrictInCity(locationList);
+      if(!otherCityList.isEmpty()){
+        return qPost.location.city.in(city)
+            .or(qPost.location.in(otherCityList));
+      }
 
-                postIdByLocationFilter.where(locationTagCondition);
-            }
-        }
-        return postIdByLocationFilter.fetch();
+      return qPost.location.city.in(city);
+
     }
+    return qPost.location.in(locationList);
+  }
 
-    private boolean checkSearchAllCity(List<Location> locationList){
-        List<Location> allCity = List.of(new Location(findAllCityId(),0L));
-        return locationList.equals(allCity);
-    }
+  private List<Long> extractCityListForEntireDistrict(List<Location> locationList, Long districtEntireValue){
 
-    private Long findAllCityId(){
+    return locationList.stream()
+        .filter(location -> location.getDistrict().equals(districtEntireValue))
+        .map(Location::getCity)
+        .distinct()
+        .toList();
+  }
 
-        return jpaQueryFactory
-                .select(qCity.id)
-                .from(qCity)
-                .where(qCity.city.eq("전국"))
-                .fetchOne();
-    }
-
-    public BooleanExpression createTagCondition(QPostTag postTag, List<Long> tagIds){
-
-        if(tagIds == null || tagIds.isEmpty()){
-
-            log.info("tagIds is null or Empty");
-            return null;
-        }
-
-        return postTag.tagId.in(tagIds);
-    }
-
-    private BooleanExpression checkSearchAllDistrictInCity(List<Location> locationList){
-        Long districtEntireValue = 0L;
-
-        boolean hasDistrictEntireValue = locationList.stream()
-                .anyMatch(location -> location.getDistrict().equals(districtEntireValue));
-
-        if (hasDistrictEntireValue) {
-            List<Long> city = extractCityListForEntireDistrict(locationList, districtEntireValue);
-            List<Location> otherCityList = extractCityListForOtherDistrict(locationList, districtEntireValue);
-
-            if(!otherCityList.isEmpty()){
-                return qPost.location.city.in(city)
-                        .or(qPost.location.in(otherCityList));
-            }
-
-            return qPost.location.city.in(city);
-
-        }
-        return qPost.location.in(locationList);
-    }
-
-    private List<Long> extractCityListForEntireDistrict(List<Location> locationList, Long districtEntireValue){
-
-        return locationList.stream()
-                .filter(location -> location.getDistrict().equals(districtEntireValue))
-                .map(Location::getCity)
-                .distinct()
-                .toList();
-    }
-
-    private List<Location> extractCityListForOtherDistrict(List<Location> locationList, Long districtEntireValue){
-        return locationList.stream()
-                .filter(location -> !location.getDistrict().equals(districtEntireValue))
-                .toList();
-    }
-
-    public BooleanExpression havingCondition(NumberPath<Long> tagId, List<Long> tagIds){
-        return Expressions.numberTemplate(Long.class,
-                "SUM(CASE WHEN {0} IN {1} THEN 1 ELSE 0 END)", tagId, tagIds).gt(0);
-    }
-
-    public void createWhereAndHavingCondition(BooleanExpression tagCondition, List<Long> tagIds){
-        if(tagCondition != null){
-
-            log.info("tagCondition is not null");
-
-            tagConditions.or(tagCondition);
-            havingConditions.and(havingCondition(qPostTag.tagId, tagIds));
-        }
-    }
-
-    private OrderSpecifier<?> getSortColumn(Sort sort){
-
-        if (sort == null || sort.isEmpty()) {
-            return new OrderSpecifier<>(Order.DESC, qPost.createdAt); //기본 정렬
-        }
-
-        Sort.Order order = sort.iterator().next();
-        String sortColumn = order.getProperty();
-        Order direction = order.getDirection() == Sort.Direction.ASC ? Order.ASC : Order.DESC;
-
-        return switch (sortColumn) {
-            case "createdAt" -> new OrderSpecifier<>(direction, qPost.createdAt);
-            case "likeCount" -> new OrderSpecifier<>(direction, qPost.likeCount);
-            default -> new OrderSpecifier<>(Order.DESC, qPost.createdAt);
-        };
-    }
-
-    private List<PostWithLocationName> getQueryByFilters(List<Long> postIdsByLocation, List<Long> postIdsByTag, Pageable pageable, List<Long> invisiblePostIdsList){
-
-        OrderSpecifier<?> sortType = getSortColumn(pageable.getSort());
-
-        return jpaQueryFactory
-                .select(Projections.constructor(PostWithLocationName.class,
-                        qPost.id.as("postId"),
-                        qPost.thumbnailImageId.as("thumbnailImageId"),
-                        qCity.city.as("cityName"),
-                        qDistrict.district.as("districtName")
-                ))
-                .from(qPost)
-                .leftJoin(qCity).on(qPost.location.city.eq(qCity.id))
-                .leftJoin(qDistrict).on(qPost.location.district.eq(qDistrict.id))
-                .where(
-                        qPost.id.in(postIdsByLocation),
-                        qPost.id.in(postIdsByTag),
-                        qPost.id.notIn(invisiblePostIdsList)
-                )
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
-                .orderBy(sortType)
-                .fetch();
-    }
-
-    private JPAQuery<Long> getPostsQueryCount(List<Long> postIdsByLocation, List<Long> postIdsByTag, List<Long> invisiblePostIdsList){
-
-        return jpaQueryFactory
-                .select(qPost.count())
-                .from(qPost)
-                .where(
-                        qPost.id.in(postIdsByLocation),
-                        qPost.id.in(postIdsByTag),
-                        qPost.id.notIn(invisiblePostIdsList)
-                );
-    }
+  private List<Location> extractCityListForOtherDistrict(List<Location> locationList, Long districtEntireValue){
+    return locationList.stream()
+        .filter(location -> !location.getDistrict().equals(districtEntireValue))
+        .toList();
+  }
 }

--- a/src/main/java/com/WearWeather/wear/domain/post/repository/PostByFilterRepositoryCustomImpl.java
+++ b/src/main/java/com/WearWeather/wear/domain/post/repository/PostByFilterRepositoryCustomImpl.java
@@ -39,7 +39,6 @@ public class PostByFilterRepositoryCustomImpl implements PostByFilterRepositoryC
   @Override
   public Page<PostWithLocationName> findPostsByFilters(PostsByFiltersRequest request, Pageable pageable, List<Long> invisiblePostIdsList) {
 
-
     BooleanBuilder conditions = createConditions(request, invisiblePostIdsList);
 
     List<PostWithLocationName> posts = getQueryByFilters(pageable, conditions);
@@ -66,33 +65,19 @@ public class PostByFilterRepositoryCustomImpl implements PostByFilterRepositoryC
 
     return conditions;
   }
+
   public List<Long> findPostIdByTagFilter(PostsByFiltersRequest request){
 
     BooleanBuilder tagConditions = new BooleanBuilder();
     BooleanBuilder havingConditions = new BooleanBuilder();
 
-    List<Long> seasonTagIds = request.getSeasonTagIds();
-    List<Long> weatherTagIds = request.getWeatherTagIds();
-    List<Long> temperatureTagIds = request.getTemperatureTagIds();
+    createTagConditions(request.getSeasonTagIds(), tagConditions, havingConditions);
+    createTagConditions(request.getWeatherTagIds(), tagConditions, havingConditions);
+    createTagConditions(request.getTemperatureTagIds(), tagConditions, havingConditions);
 
     JPAQuery<Long> postIdByTagFilter = jpaQueryFactory.select(qPostTag.postId)
         .from(qPostTag)
         .groupBy(qPostTag.postId);
-
-    if(!seasonTagIds.isEmpty()){
-      tagConditions.or(qPostTag.tagId.in(seasonTagIds));
-      havingConditions.and(havingCondition(qPostTag.tagId, seasonTagIds));
-    }
-
-    if(!weatherTagIds.isEmpty()){
-      tagConditions.or(qPostTag.tagId.in(weatherTagIds));
-      havingConditions.and(havingCondition(qPostTag.tagId, weatherTagIds));
-    }
-
-    if(!temperatureTagIds.isEmpty()){
-      tagConditions.or(qPostTag.tagId.in(temperatureTagIds));
-      havingConditions.and(havingCondition(qPostTag.tagId, temperatureTagIds));
-    }
 
     if(tagConditions.hasValue()){
       postIdByTagFilter.where(tagConditions);
@@ -103,6 +88,13 @@ public class PostByFilterRepositoryCustomImpl implements PostByFilterRepositoryC
     }
 
     return postIdByTagFilter.fetch();
+  }
+
+  private void createTagConditions(List<Long> tagIds, BooleanBuilder tagConditions, BooleanBuilder havingConditions) {
+    if (!tagIds.isEmpty()) {
+      tagConditions.or(qPostTag.tagId.in(tagIds));
+      havingConditions.and(havingCondition(qPostTag.tagId, tagIds));
+    }
   }
 
   public BooleanBuilder findPostIdByLocationFilter(PostsByFiltersRequest request) {

--- a/src/main/java/com/WearWeather/wear/domain/post/repository/PostByFilterRepositoryCustomImpl.java
+++ b/src/main/java/com/WearWeather/wear/domain/post/repository/PostByFilterRepositoryCustomImpl.java
@@ -13,8 +13,10 @@ import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.NumberPath;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -22,9 +24,11 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.support.PageableExecutionUtils;
 
+import java.util.List;
+
 @Slf4j
 @RequiredArgsConstructor
-public class PostByFilterRepositoryCustomImpl implements PostByFilterRepositoryCustom{
+public class PostByFilterRepositoryCustomImpl implements PostByFilterRepositoryCustom {
   private final JPAQueryFactory jpaQueryFactory;
 
   QPost qPost = QPost.post;
@@ -32,87 +36,113 @@ public class PostByFilterRepositoryCustomImpl implements PostByFilterRepositoryC
   QCity qCity = QCity.city1;
   QDistrict qDistrict = QDistrict.district1;
 
+//  BooleanBuilder tagConditions = new BooleanBuilder();
+//  BooleanBuilder havingConditions = new BooleanBuilder();
+
   @Override
-  public Page<PostWithLocationName> findPostsByFilters (
-      PostsByFiltersRequest request, Pageable pageable, List<Long> hiddenPostIds) {
-    BooleanBuilder conditions = new BooleanBuilder();
+  public Page<PostWithLocationName> findPostsByFilters(PostsByFiltersRequest request, Pageable pageable, List<Long> invisiblePostIdsList) {
 
-    // 태그 조건 추가
-    addTagConditions(request, conditions);
+    BooleanBuilder tagConditions = new BooleanBuilder();
+    BooleanBuilder havingConditions = new BooleanBuilder();
 
-    // 위치 조건 추가
-    addLocationConditions(request, conditions);
+    List<Long> postIdsByLocation = findPostIdByLocationFilter(request);
+    List<Long> postIdsByTag = findPostIdByTagFilter(request, tagConditions, havingConditions);
 
-    // 숨겨진 포스트 조건 추가
-    if (!hiddenPostIds.isEmpty()) {
-      conditions.and(qPost.id.notIn(hiddenPostIds));
-    }
+    log.info( " postIdByLocation = {}", postIdsByLocation.toString() );
+    log.info( " postIdsByTag = {}", postIdsByTag.toString() );
 
-    List<PostWithLocationName> posts = jpaQueryFactory
-        .select(Projections.constructor(PostWithLocationName.class,
-            qPost.id.as("postId"),
-            qPost.thumbnailImageId.as("thumbnailImageId"),
-            qCity.city.as("cityName"),
-            qDistrict.district.as("districtName")))
-        .from(qPost)
-        .leftJoin(qCity).on(qPost.location.city.eq(qCity.id))
-        .leftJoin(qDistrict).on(qPost.location.district.eq(qDistrict.id))
-        .where(conditions)
-        .offset(pageable.getOffset())
-        .limit(pageable.getPageSize())
-        .orderBy(getSortColumn(pageable.getSort()))
-        .fetch();
+    List<PostWithLocationName> posts = getQueryByFilters(postIdsByLocation, postIdsByTag, pageable, invisiblePostIdsList);
+    JPAQuery<Long> postsQueryCount = getPostsQueryCount(postIdsByLocation, postIdsByTag, invisiblePostIdsList);
 
-    long totalCount = jpaQueryFactory
-        .select(qPost.count())
-        .from(qPost)
-        .where(conditions)
-        .fetchOne();
+    return PageableExecutionUtils.getPage(posts, pageable, postsQueryCount::fetchOne);
 
-    return PageableExecutionUtils.getPage(posts, pageable, () -> totalCount);
   }
 
-  private void addTagConditions(PostsByFiltersRequest request, BooleanBuilder conditions) {
+  public List<Long> findPostIdByTagFilter(PostsByFiltersRequest request, BooleanBuilder tagConditions, BooleanBuilder havingConditions){
+
     List<Long> seasonTagIds = request.getSeasonTagIds();
     List<Long> weatherTagIds = request.getWeatherTagIds();
     List<Long> temperatureTagIds = request.getTemperatureTagIds();
 
-    if (!seasonTagIds.isEmpty()) {
-      conditions.or(qPostTag.tagId.in(seasonTagIds));
+    log.info( " seasonTagIds = {}", seasonTagIds.toString() );
+    log.info( " weatherTagIds = {}", weatherTagIds.toString() );
+    log.info( " temperatureTagIds = {}", temperatureTagIds.toString() );
+
+    JPAQuery<Long> postIdByTagFilter = jpaQueryFactory.select(qPostTag.postId)
+        .from(qPostTag)
+        .groupBy(qPostTag.postId);
+
+    BooleanExpression seasonTagCondition = createTagCondition(qPostTag, seasonTagIds);
+    createWhereAndHavingCondition(seasonTagCondition, seasonTagIds, tagConditions, havingConditions);
+
+    BooleanExpression weatherTagCondition = createTagCondition(qPostTag, weatherTagIds);
+    createWhereAndHavingCondition(weatherTagCondition, weatherTagIds, tagConditions, havingConditions);
+
+    BooleanExpression temperatureTagCondition = createTagCondition(qPostTag, temperatureTagIds);
+    createWhereAndHavingCondition(temperatureTagCondition, temperatureTagIds, tagConditions, havingConditions);
+
+    if(tagConditions.hasValue()){
+      postIdByTagFilter.where(tagConditions);
+
+      log.info("tagConditions has value");
     }
-    if (!weatherTagIds.isEmpty()) {
-      conditions.or(qPostTag.tagId.in(weatherTagIds));
+
+    if(havingConditions.hasValue()){
+      postIdByTagFilter.having(havingConditions);
+
+      log.info("havingConditions has value");
+
     }
-    if (!temperatureTagIds.isEmpty()) {
-      conditions.or(qPostTag.tagId.in(temperatureTagIds));
-    }
+
+    return postIdByTagFilter.fetch();
   }
 
-  private void addLocationConditions(PostsByFiltersRequest request, BooleanBuilder conditions) {
+  public List<Long> findPostIdByLocationFilter(PostsByFiltersRequest request) {
+
     List<Location> locationList = request.getLocationList().stream()
         .map(LocationRequest::toEntity)
         .toList();
 
+    JPAQuery<Long> postIdByLocationFilter = jpaQueryFactory
+        .select(qPost.id)
+        .from(qPost);
+
     if (!locationList.isEmpty()) {
-      conditions.and(checkSearchAllDistrictInCity(locationList));
+
+      boolean hasCityEntireValue = checkSearchAllCity(locationList);
+
+      if (!hasCityEntireValue) {
+        BooleanExpression locationTagCondition = checkSearchAllDistrictInCity(locationList);
+
+        postIdByLocationFilter.where(locationTagCondition);
+      }
     }
+    return postIdByLocationFilter.fetch();
   }
 
-  private OrderSpecifier<?> getSortColumn(Sort sort){
+  private boolean checkSearchAllCity(List<Location> locationList){
+    List<Location> allCity = List.of(new Location(findAllCityId(),0L));
+    return locationList.equals(allCity);
+  }
 
-    if (sort == null || sort.isEmpty()) {
-      return new OrderSpecifier<>(Order.DESC, qPost.createdAt); //기본 정렬
+  private Long findAllCityId(){
+
+    return jpaQueryFactory
+        .select(qCity.id)
+        .from(qCity)
+        .where(qCity.city.eq("전국"))
+        .fetchOne();
+  }
+
+  public BooleanExpression createTagCondition(QPostTag postTag, List<Long> tagIds){
+
+    if(tagIds == null || tagIds.isEmpty()){
+
+      log.info("tagIds is null or Empty");
+      return null;
     }
 
-    Sort.Order order = sort.iterator().next();
-    String sortColumn = order.getProperty();
-    Order direction = order.getDirection() == Sort.Direction.ASC ? Order.ASC : Order.DESC;
-
-    return switch (sortColumn) {
-      case "createdAt" -> new OrderSpecifier<>(direction, qPost.createdAt);
-      case "likeCount" -> new OrderSpecifier<>(direction, qPost.likeCount);
-      default -> new OrderSpecifier<>(Order.DESC, qPost.createdAt);
-    };
+    return postTag.tagId.in(tagIds);
   }
 
   private BooleanExpression checkSearchAllDistrictInCity(List<Location> locationList){
@@ -149,5 +179,74 @@ public class PostByFilterRepositoryCustomImpl implements PostByFilterRepositoryC
     return locationList.stream()
         .filter(location -> !location.getDistrict().equals(districtEntireValue))
         .toList();
+  }
+
+  public BooleanExpression havingCondition(NumberPath<Long> tagId, List<Long> tagIds){
+    return Expressions.numberTemplate(Long.class,
+        "SUM(CASE WHEN {0} IN {1} THEN 1 ELSE 0 END)", tagId, tagIds).gt(0);
+  }
+
+  public void createWhereAndHavingCondition(BooleanExpression tagCondition1, List<Long> tagIds, BooleanBuilder tagConditions, BooleanBuilder havingConditions){
+    if(tagCondition1 != null){
+
+      log.info("tagCondition is not null");
+
+      tagConditions.or(tagCondition1);
+      havingConditions.and(havingCondition(qPostTag.tagId, tagIds));
+    }
+  }
+
+  private OrderSpecifier<?> getSortColumn(Sort sort){
+
+    if (sort == null || sort.isEmpty()) {
+      return new OrderSpecifier<>(Order.DESC, qPost.createdAt); //기본 정렬
+    }
+
+    Sort.Order order = sort.iterator().next();
+    String sortColumn = order.getProperty();
+    Order direction = order.getDirection() == Sort.Direction.ASC ? Order.ASC : Order.DESC;
+
+    return switch (sortColumn) {
+      case "createdAt" -> new OrderSpecifier<>(direction, qPost.createdAt);
+      case "likeCount" -> new OrderSpecifier<>(direction, qPost.likeCount);
+      default -> new OrderSpecifier<>(Order.DESC, qPost.createdAt);
+    };
+  }
+
+  private List<PostWithLocationName> getQueryByFilters(List<Long> postIdsByLocation, List<Long> postIdsByTag, Pageable pageable, List<Long> invisiblePostIdsList){
+
+    OrderSpecifier<?> sortType = getSortColumn(pageable.getSort());
+
+    return jpaQueryFactory
+        .select(Projections.constructor(PostWithLocationName.class,
+            qPost.id.as("postId"),
+            qPost.thumbnailImageId.as("thumbnailImageId"),
+            qCity.city.as("cityName"),
+            qDistrict.district.as("districtName")
+        ))
+        .from(qPost)
+        .leftJoin(qCity).on(qPost.location.city.eq(qCity.id))
+        .leftJoin(qDistrict).on(qPost.location.district.eq(qDistrict.id))
+        .where(
+            qPost.id.in(postIdsByLocation),
+            qPost.id.in(postIdsByTag),
+            qPost.id.notIn(invisiblePostIdsList)
+        )
+        .offset(pageable.getOffset())
+        .limit(pageable.getPageSize())
+        .orderBy(sortType)
+        .fetch();
+  }
+
+  private JPAQuery<Long> getPostsQueryCount(List<Long> postIdsByLocation, List<Long> postIdsByTag, List<Long> invisiblePostIdsList){
+
+    return jpaQueryFactory
+        .select(qPost.count())
+        .from(qPost)
+        .where(
+            qPost.id.in(postIdsByLocation),
+            qPost.id.in(postIdsByTag),
+            qPost.id.notIn(invisiblePostIdsList)
+        );
   }
 }


### PR DESCRIPTION
## 개요
서버에서 필터 검색의 오류가 발생하여 코드 수정

## 개선 사항
1. 필터 검색을 여러번 진행하였을 때 빈 배열을 반환한다 
 -> 조건이 전역변수로 설정되어있어 조건을 초기화하지않는다.
 -> 각 필터 조건을 초기화하는 메서드를 추가하여 전역변수 문제를 해결
2. 낮은 가독성
 -> 중첩된 메서드를 줄임
 -> 조건 처리 로직을 메서드로 분리하여 각각의 필터 조건을 명확하게 처리 

