### PR TITLE
쿠키 설정 변경

### DIFF
--- a/src/main/java/com/WearWeather/wear/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/WearWeather/wear/domain/auth/controller/AuthController.java
@@ -44,7 +44,7 @@ public class AuthController {
         String refreshToken = tokenProvider.renewRefreshToken(loginResponse.getAccessToken());
         ResponseCookie refreshTokenCookie = ResponseCookie.from("refreshToken", refreshToken)
             .path("/")
-            .sameSite("None")
+            .sameSite("Strict")
             .httpOnly(true)
             .secure(true)
             .domain("lookattheweather.store")

--- a/src/main/java/com/WearWeather/wear/domain/oauth/controller/OAuthController.java
+++ b/src/main/java/com/WearWeather/wear/domain/oauth/controller/OAuthController.java
@@ -33,7 +33,7 @@ public class OAuthController {
         String refreshToken = tokenProvider.renewRefreshToken(loginResponse.getAccessToken());
         ResponseCookie refreshTokenCookie = ResponseCookie.from("refreshToken", refreshToken)
             .path("/")
-            .sameSite("None")
+            .sameSite("Strict")
             .httpOnly(true)
             .secure(true)
             .domain("lookattheweather.store")


### PR DESCRIPTION
## PR 개요
- 프론트와 백엔드 도메인 서버를 일치시키고 쿠키에 대한 보안 강화를 위해  sameSite 설정을 수정합니다.

## 주요 작업 내용
- sameSite("None")에서 ("Strict")으로 수정
