### PR TITLE
토큰 재발급 시 무한으로 요청되는 버그 수정

### DIFF
--- a/src/main/java/com/WearWeather/wear/global/jwt/JwtFilter.java
+++ b/src/main/java/com/WearWeather/wear/global/jwt/JwtFilter.java
@@ -26,7 +26,8 @@ public class JwtFilter extends GenericFilterBean {
 
     private static final Logger logger = LoggerFactory.getLogger(JwtFilter.class);
     public static final String AUTHORIZATION_HEADER = "Authorization";
-    private final TokenProvider tokenProvider; 
+    private final TokenProvider tokenProvider;
+    public static final String USERS_REISSUE = "/users/reissue";
 
     // 토큰의 인증정보(ID, 권한 정보 등)를 SecurityContext에 저장
     @Override
@@ -35,9 +36,16 @@ public class JwtFilter extends GenericFilterBean {
 
         HttpServletRequest httpServletRequest = (HttpServletRequest) servletRequest;
         HttpServletResponse httpServletResponse = (HttpServletResponse) servletResponse; // 응답 객체 가져오기
-        String jwt = resolveToken(httpServletRequest);
-        String requestURI = httpServletRequest.getRequestURI();
 
+        String requestURI = httpServletRequest.getRequestURI();
+        // 특정 API 제외
+        if (USERS_REISSUE.equals(requestURI)) {
+            logger.debug("JWT 필터를 건너뜀: {}", requestURI);
+            filterChain.doFilter(servletRequest, servletResponse);
+            return;
+        }
+
+        String jwt = resolveToken(httpServletRequest);
         try {
             if (StringUtils.hasText(jwt) && tokenProvider.validateToken(jwt)) {
                 Authentication authentication = tokenProvider.getAuthentication(jwt);


### PR DESCRIPTION
문제
---
- AT 토큰이 만료됨 
- 새롭게 갱신받기 위해 ressiue api를 요청 함
- 해당 api 요청 시 필터가 가로채서 만료된 토큰을 가지고 유효성 검사를 한다
- 따라서 ressiue api가 무한으로 요청되고 있는 문제 발생 

문제 해결
---
ressiue api 요청시에는 필터가 해당 url에 대해서 수행되지 않도록 수정

