### PR TITLE
주소 검색 API 에러 수정

### DIFF
--- a/src/main/java/com/WearWeather/wear/domain/location/controller/LocationController.java
+++ b/src/main/java/com/WearWeather/wear/domain/location/controller/LocationController.java
@@ -4,6 +4,7 @@ import com.WearWeather.wear.domain.location.dto.response.GeocodingLocationRespon
 import com.WearWeather.wear.domain.location.dto.response.RegionsResponse;
 import com.WearWeather.wear.domain.location.dto.response.SearchLocationResponse;
 import com.WearWeather.wear.domain.location.service.LocationService;
+import java.util.Collections;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -28,7 +29,11 @@ public class LocationController {
     }
 
     @GetMapping("/location/search")
-    public List<SearchLocationResponse> searchLocation(@RequestParam("address") String address){
+    public List<SearchLocationResponse> searchLocation(@RequestParam(required = true, value= "address") String address){
+        if(address.isEmpty()){
+            return Collections.emptyList();
+        }
+
         return locationService.searchLocation(address);
     }
 

--- a/src/main/java/com/WearWeather/wear/domain/location/service/LocationService.java
+++ b/src/main/java/com/WearWeather/wear/domain/location/service/LocationService.java
@@ -372,7 +372,13 @@ public class LocationService {
             }
 
             for (JsonNode document : documents) {
-                JsonNode address = document.path("address");
+
+                JsonNode address;
+                if(!document.path("address").isNull()){
+                    address = document.path("address");
+                }else {
+                    address = document.path("road_address");
+                }
 
                 String address_full_name = document.path("address_name").asText();
                 String longitude = String.format("%.4f", document.path("x").asDouble());


### PR DESCRIPTION
## 개요
카카오 주소 검색에서 발생하는 에러를 처리한다.

## 구현 기능
1. 파라미터 값이 빈 값일 때 빈 배열을 반환한다.
2. API에서 제공하는 결과 값의 형태에 따라 mapping을 다르게 처리한다.