### PR TITLE
게시글 내 성별 컬럼 추가

### DIFF
--- a/src/main/java/com/WearWeather/wear/domain/post/dto/request/PostCreateRequest.java
+++ b/src/main/java/com/WearWeather/wear/domain/post/dto/request/PostCreateRequest.java
@@ -5,6 +5,7 @@ import com.WearWeather.wear.domain.post.entity.Location;
 import com.WearWeather.wear.domain.post.entity.Post;
 import com.WearWeather.wear.domain.postImage.dto.request.PostImageRequest;
 import com.WearWeather.wear.domain.tag.dto.TaggableRequest;
+import com.WearWeather.wear.global.validation.Enum;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotBlank;
@@ -31,6 +32,7 @@ public class PostCreateRequest implements PostImageRequest, TaggableRequest {
     @NotNull
     private final int temperature;
 
+    @Enum(target = Gender.class, message = "올바른 성별 값을 입력해주세요.")
     private final Gender gender;
 
     @NotBlank

--- a/src/main/java/com/WearWeather/wear/domain/post/dto/request/PostCreateRequest.java
+++ b/src/main/java/com/WearWeather/wear/domain/post/dto/request/PostCreateRequest.java
@@ -1,5 +1,6 @@
 package com.WearWeather.wear.domain.post.dto.request;
 
+import com.WearWeather.wear.domain.post.entity.Gender;
 import com.WearWeather.wear.domain.post.entity.Location;
 import com.WearWeather.wear.domain.post.entity.Post;
 import com.WearWeather.wear.domain.postImage.dto.request.PostImageRequest;
@@ -27,8 +28,10 @@ public class PostCreateRequest implements PostImageRequest, TaggableRequest {
     @Size(max = 50)
     private final String content;
 
-    @NotBlank
+    @NotNull
     private final int temperature;
+    
+    private final Gender gender;
 
     @NotBlank
     private final String city;
@@ -55,6 +58,7 @@ public class PostCreateRequest implements PostImageRequest, TaggableRequest {
         @JsonProperty("title") String title,
         @JsonProperty("content") String content,
         @JsonProperty("temperature") int temperature,
+        @JsonProperty("gender") Gender gender,
         @JsonProperty("city") String city,
         @JsonProperty("district") String district,
         @JsonProperty("weatherTagIds") Set<Long> weatherTagIds,
@@ -64,6 +68,7 @@ public class PostCreateRequest implements PostImageRequest, TaggableRequest {
         this.title = title;
         this.content = content;
         this.temperature = temperature;
+        this.gender = gender;
         this.city = city;
         this.district = district;
         this.weatherTagIds = weatherTagIds;
@@ -77,6 +82,7 @@ public class PostCreateRequest implements PostImageRequest, TaggableRequest {
             .title(title)
             .content(content)
             .temperature(temperature)
+            .gender(gender)
             .location(location)
             .build();
     }

--- a/src/main/java/com/WearWeather/wear/domain/post/dto/request/PostCreateRequest.java
+++ b/src/main/java/com/WearWeather/wear/domain/post/dto/request/PostCreateRequest.java
@@ -30,7 +30,7 @@ public class PostCreateRequest implements PostImageRequest, TaggableRequest {
 
     @NotNull
     private final int temperature;
-    
+
     private final Gender gender;
 
     @NotBlank

--- a/src/main/java/com/WearWeather/wear/domain/post/dto/request/PostUpdateRequest.java
+++ b/src/main/java/com/WearWeather/wear/domain/post/dto/request/PostUpdateRequest.java
@@ -1,5 +1,6 @@
 package com.WearWeather.wear.domain.post.dto.request;
 
+import com.WearWeather.wear.domain.post.entity.Gender;
 import com.WearWeather.wear.domain.postImage.dto.request.PostImageRequest;
 import com.WearWeather.wear.domain.tag.dto.TaggableRequest;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -31,6 +32,8 @@ public class PostUpdateRequest implements PostImageRequest, TaggableRequest {
     @NotBlank
     private final String district;
 
+    private final Gender gender;
+
     @NotNull
     @Size(max = 2)
     private final Set<Long> weatherTagIds;
@@ -51,6 +54,7 @@ public class PostUpdateRequest implements PostImageRequest, TaggableRequest {
         @JsonProperty("content") String content,
         @JsonProperty("city") String city,
         @JsonProperty("district") String district,
+        @JsonProperty("gender") Gender gender,
         @JsonProperty("weatherTagIds") Set<Long> weatherTagIds,
         @JsonProperty("temperatureTagIds") Set<Long> temperatureTagIds,
         @JsonProperty("seasonTagId") Long seasonTagId
@@ -59,6 +63,7 @@ public class PostUpdateRequest implements PostImageRequest, TaggableRequest {
         this.content = content;
         this.city = city;
         this.district = district;
+        this.gender = gender;
         this.weatherTagIds = weatherTagIds;
         this.temperatureTagIds = temperatureTagIds;
         this.seasonTagId = seasonTagId;

--- a/src/main/java/com/WearWeather/wear/domain/post/dto/request/PostsByFiltersRequest.java
+++ b/src/main/java/com/WearWeather/wear/domain/post/dto/request/PostsByFiltersRequest.java
@@ -24,6 +24,8 @@ public record PostsByFiltersRequest (
     List<Long> weatherTagIds,
     List<Long> temperatureTagIds,
 
+    String gender,
+
     @NotNull(message = "정렬 방법은 필수입니다.")
     SortType sort
 ){

--- a/src/main/java/com/WearWeather/wear/domain/post/dto/request/PostsByFiltersRequest.java
+++ b/src/main/java/com/WearWeather/wear/domain/post/dto/request/PostsByFiltersRequest.java
@@ -1,6 +1,8 @@
 package com.WearWeather.wear.domain.post.dto.request;
 
+import com.WearWeather.wear.domain.post.entity.GenderFilter;
 import com.WearWeather.wear.domain.post.entity.SortType;
+import com.WearWeather.wear.global.validation.Enum;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
@@ -24,6 +26,7 @@ public record PostsByFiltersRequest (
     List<Long> weatherTagIds,
     List<Long> temperatureTagIds,
 
+    @Enum(target = GenderFilter.class, message = "올바른 성별 필터 값을 입력해주세요.")
     String gender,
 
     @NotNull(message = "정렬 방법은 필수입니다.")

--- a/src/main/java/com/WearWeather/wear/domain/post/dto/response/PostWithLocationName.java
+++ b/src/main/java/com/WearWeather/wear/domain/post/dto/response/PostWithLocationName.java
@@ -1,9 +1,12 @@
 package com.WearWeather.wear.domain.post.dto.response;
 
+import com.WearWeather.wear.domain.post.entity.Gender;
+
 public record PostWithLocationName(
         Long postId,
         Long thumbnailImageId,
         String cityName,
-        String districtName
+        String districtName,
+        Gender gender
 ) {
 }

--- a/src/main/java/com/WearWeather/wear/domain/post/dto/response/SearchPostResponse.java
+++ b/src/main/java/com/WearWeather/wear/domain/post/dto/response/SearchPostResponse.java
@@ -1,4 +1,5 @@
 package com.WearWeather.wear.domain.post.dto.response;
+import com.WearWeather.wear.domain.post.entity.Gender;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -18,8 +19,9 @@ public class SearchPostResponse {
     private final List<String> weatherTags;
     private final List<String> temperatureTags;
     private final boolean likeByUser;
+    private final Gender gender;
 
-    public static SearchPostResponse of(PostWithLocationName post, String url, Map<String, List<String>> tags, boolean like){
+    public static SearchPostResponse of(PostWithLocationName post, String url, Map<String, List<String>> tags, boolean like, Gender gender){
         return SearchPostResponse.builder()
                 .postId(post.postId())
                 .thumbnail(url)
@@ -28,6 +30,7 @@ public class SearchPostResponse {
                 .weatherTags(tags.get("WEATHER"))
                 .temperatureTags(tags.get("TEMPERATURE"))
                 .likeByUser(like)
+                .gender(gender)
                 .build();
     }
 

--- a/src/main/java/com/WearWeather/wear/domain/post/entity/Gender.java
+++ b/src/main/java/com/WearWeather/wear/domain/post/entity/Gender.java
@@ -1,0 +1,6 @@
+package com.WearWeather.wear.domain.post.entity;
+
+public enum Gender {
+    MALE,
+    FEMALE
+}

--- a/src/main/java/com/WearWeather/wear/domain/post/entity/Gender.java
+++ b/src/main/java/com/WearWeather/wear/domain/post/entity/Gender.java
@@ -1,5 +1,8 @@
 package com.WearWeather.wear.domain.post.entity;
 
+import lombok.Getter;
+
+@Getter
 public enum Gender {
     MALE,
     FEMALE

--- a/src/main/java/com/WearWeather/wear/domain/post/entity/GenderFilter.java
+++ b/src/main/java/com/WearWeather/wear/domain/post/entity/GenderFilter.java
@@ -1,11 +1,13 @@
 package com.WearWeather.wear.domain.post.entity;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
-public enum Gender {
+@AllArgsConstructor
+public enum GenderFilter {
+    ALL,
     MALE,
     FEMALE;
 
 }
-

--- a/src/main/java/com/WearWeather/wear/domain/post/entity/Post.java
+++ b/src/main/java/com/WearWeather/wear/domain/post/entity/Post.java
@@ -72,9 +72,10 @@ public class Post extends BaseTimeEntity implements Serializable {
         return this.likeCount;
     }
 
-    public void updatePostDetails(String title, String content, Location location) {
+    public void updatePostDetails(String title, String content, Gender gender, Location location) {
         this.title = title;
         this.content = content;
+        this.gender = gender;
         this.location = location;
     }
 }

--- a/src/main/java/com/WearWeather/wear/domain/post/entity/Post.java
+++ b/src/main/java/com/WearWeather/wear/domain/post/entity/Post.java
@@ -44,6 +44,9 @@ public class Post extends BaseTimeEntity implements Serializable {
     @Column(name = "tmp", nullable = false)
     private int temperature;
 
+    @Column(name = "gender", nullable = false)
+    private Gender gender;
+
     @Column(name = "likeCount", nullable = false)
     private int likeCount = 0;
 

--- a/src/main/java/com/WearWeather/wear/domain/post/entity/Post.java
+++ b/src/main/java/com/WearWeather/wear/domain/post/entity/Post.java
@@ -4,6 +4,8 @@ import com.WearWeather.wear.global.common.BaseTimeEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -44,7 +46,7 @@ public class Post extends BaseTimeEntity implements Serializable {
     @Column(name = "tmp", nullable = false)
     private int temperature;
 
-    @Column(name = "gender", nullable = false)
+    @Enumerated(EnumType.STRING)
     private Gender gender;
 
     @Column(name = "likeCount", nullable = false)

--- a/src/main/java/com/WearWeather/wear/domain/post/repository/PostByFilterRepositoryCustomImpl.java
+++ b/src/main/java/com/WearWeather/wear/domain/post/repository/PostByFilterRepositoryCustomImpl.java
@@ -5,6 +5,7 @@ import com.WearWeather.wear.domain.location.entity.QDistrict;
 import com.WearWeather.wear.domain.post.dto.request.LocationRequest;
 import com.WearWeather.wear.domain.post.dto.request.PostsByFiltersRequest;
 import com.WearWeather.wear.domain.post.dto.response.PostWithLocationName;
+import com.WearWeather.wear.domain.post.entity.Gender;
 import com.WearWeather.wear.domain.post.entity.Location;
 import com.WearWeather.wear.domain.post.entity.QPost;
 import com.WearWeather.wear.domain.postTag.entity.QPostTag;
@@ -62,6 +63,10 @@ public class PostByFilterRepositoryCustomImpl implements PostByFilterRepositoryC
 
     if (!invisiblePostIdsList.isEmpty()) {
       conditions.and(qPost.id.notIn(invisiblePostIdsList));
+    }
+
+    if(!request.gender().equals("ALL")){
+      conditions.and(qPost.gender.eq(Gender.valueOf(request.gender())));
     }
 
     return conditions;
@@ -190,7 +195,8 @@ public class PostByFilterRepositoryCustomImpl implements PostByFilterRepositoryC
             qPost.id.as("postId"),
             qPost.thumbnailImageId.as("thumbnailImageId"),
             qCity.city.as("cityName"),
-            qDistrict.district.as("districtName")
+            qDistrict.district.as("districtName"),
+            qPost.gender.as("gender")
         ))
         .from(qPost)
         .leftJoin(qCity).on(qPost.location.city.eq(qCity.id))

--- a/src/main/java/com/WearWeather/wear/domain/post/service/PostService.java
+++ b/src/main/java/com/WearWeather/wear/domain/post/service/PostService.java
@@ -299,7 +299,8 @@ public class PostService {
             post,
             url,
             tags,
-            like
+            like,
+            post.gender()
         );
     }
 

--- a/src/main/java/com/WearWeather/wear/domain/post/service/PostService.java
+++ b/src/main/java/com/WearWeather/wear/domain/post/service/PostService.java
@@ -93,7 +93,7 @@ public class PostService {
         Location location = locationService.findCityIdAndDistrictId(request.getCity(),request.getDistrict());
         Post post = validateUserPermission(userId, postId);
 
-        post.updatePostDetails(request.getTitle(), request.getContent(), location);
+        post.updatePostDetails(request.getTitle(), request.getContent(), request.getGender(), location);
         postImageService.updatePostImages(post, request);
         postTagService.updatePostTags(post,request);
     }

--- a/src/main/java/com/WearWeather/wear/global/exception/GlobalExceptionHandler/GlobalExceptionHandler.java
+++ b/src/main/java/com/WearWeather/wear/global/exception/GlobalExceptionHandler/GlobalExceptionHandler.java
@@ -2,14 +2,17 @@ package com.WearWeather.wear.global.exception.GlobalExceptionHandler;
 
 import com.WearWeather.wear.global.exception.CustomErrorResponse;
 import com.WearWeather.wear.global.exception.CustomException;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-    @ExceptionHandler(CustomException.class)
+    @ExceptionHandler({CustomException.class})
     public ResponseEntity<CustomErrorResponse> handleCustomException(CustomException ex) {
         CustomErrorResponse errorResponse = new CustomErrorResponse(
             ex.getHttpStatus().name(),
@@ -17,5 +20,18 @@ public class GlobalExceptionHandler {
             ex.getErrorMessage());
         return new ResponseEntity<>(errorResponse, ex.getHttpStatus());
     }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    protected ResponseEntity<CustomErrorResponse> handleException(MethodArgumentNotValidException ex) {
+
+        FieldError fieldError = ex.getBindingResult().getFieldErrors().get(0);
+        CustomErrorResponse errorResponse = new CustomErrorResponse(
+            HttpStatus.BAD_REQUEST.name(),
+            "VALIDATION_ERROR",
+            fieldError.getDefaultMessage()
+        );
+        return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
+    }
+
 
 }

--- a/src/main/java/com/WearWeather/wear/global/validation/Enum.java
+++ b/src/main/java/com/WearWeather/wear/global/validation/Enum.java
@@ -1,0 +1,21 @@
+package com.WearWeather.wear.global.validation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Constraint(validatedBy = {EnumValidator.class})
+@Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Enum {
+  String message() default "올바르지 않은 값입니다.";
+
+  Class<?>[] groups() default {};
+
+  Class<? extends Payload>[] payload() default {};
+
+  Class<? extends java.lang.Enum<?>> target();
+}

--- a/src/main/java/com/WearWeather/wear/global/validation/EnumValidator.java
+++ b/src/main/java/com/WearWeather/wear/global/validation/EnumValidator.java
@@ -1,0 +1,26 @@
+package com.WearWeather.wear.global.validation;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class EnumValidator implements ConstraintValidator<Enum, String> {
+  private Enum annotation;
+
+  @Override
+  public void initialize(Enum constraintAnnotation) {
+    this.annotation = constraintAnnotation;
+  }
+
+  @Override
+  public boolean isValid(String value, ConstraintValidatorContext context) {
+    Object[] enumValues = this.annotation.target().getEnumConstants();
+    if (enumValues != null) {
+      for (Object enumValue : enumValues) {
+        if (value.equals(enumValue.toString())) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+}


### PR DESCRIPTION
## 개요
게시글 작성 시 성별의 정보를 추가로 받아 세분화된 게시글 조회에 도움을 주도록 한다.

## 기능
1. 게시글 작성 API 성별 데이터 추가
2. 게시글 수정 API 성별 데이터 추가
3. 게시글 필터 검색 API 성별 필터 추가
4. 성별 값의 검증을 위해 ENUM 클래스 내 값인지 확인하는 커스텀 어노테이션 추가