### PR TITLE
성별 검증 오류 수정

### DIFF
--- a/src/main/java/com/WearWeather/wear/domain/post/dto/request/PostCreateRequest.java
+++ b/src/main/java/com/WearWeather/wear/domain/post/dto/request/PostCreateRequest.java
@@ -33,7 +33,7 @@ public class PostCreateRequest implements PostImageRequest, TaggableRequest {
     private final int temperature;
 
     @ValidEnum(enumClass = Gender.class, message = "올바른 성별 값을 입력해주세요.")
-    private final Gender gender;
+    private final String gender;
 
     @NotBlank
     private final String city;
@@ -60,7 +60,7 @@ public class PostCreateRequest implements PostImageRequest, TaggableRequest {
         @JsonProperty("title") String title,
         @JsonProperty("content") String content,
         @JsonProperty("temperature") int temperature,
-        @JsonProperty("gender") Gender gender,
+        @JsonProperty("gender") String gender,
         @JsonProperty("city") String city,
         @JsonProperty("district") String district,
         @JsonProperty("weatherTagIds") Set<Long> weatherTagIds,
@@ -84,7 +84,7 @@ public class PostCreateRequest implements PostImageRequest, TaggableRequest {
             .title(title)
             .content(content)
             .temperature(temperature)
-            .gender(gender)
+            .gender(Gender.valueOf(gender))
             .location(location)
             .build();
     }

--- a/src/main/java/com/WearWeather/wear/domain/post/dto/request/PostCreateRequest.java
+++ b/src/main/java/com/WearWeather/wear/domain/post/dto/request/PostCreateRequest.java
@@ -5,7 +5,7 @@ import com.WearWeather.wear.domain.post.entity.Location;
 import com.WearWeather.wear.domain.post.entity.Post;
 import com.WearWeather.wear.domain.postImage.dto.request.PostImageRequest;
 import com.WearWeather.wear.domain.tag.dto.TaggableRequest;
-import com.WearWeather.wear.global.validation.Enum;
+import com.WearWeather.wear.global.validation.ValidEnum;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotBlank;
@@ -32,7 +32,7 @@ public class PostCreateRequest implements PostImageRequest, TaggableRequest {
     @NotNull
     private final int temperature;
 
-    @Enum(target = Gender.class, message = "올바른 성별 값을 입력해주세요.")
+    @ValidEnum(enumClass = Gender.class, message = "올바른 성별 값을 입력해주세요.")
     private final Gender gender;
 
     @NotBlank

--- a/src/main/java/com/WearWeather/wear/domain/post/dto/request/PostsByFiltersRequest.java
+++ b/src/main/java/com/WearWeather/wear/domain/post/dto/request/PostsByFiltersRequest.java
@@ -27,7 +27,7 @@ public record PostsByFiltersRequest (
     List<Long> temperatureTagIds,
 
     @ValidEnum(enumClass = GenderFilter.class, message = "올바른 성별 필터 값을 입력해주세요.")
-    GenderFilter gender,
+    String gender,
 
     @NotNull(message = "정렬 방법은 필수입니다.")
     SortType sort

--- a/src/main/java/com/WearWeather/wear/domain/post/dto/request/PostsByFiltersRequest.java
+++ b/src/main/java/com/WearWeather/wear/domain/post/dto/request/PostsByFiltersRequest.java
@@ -2,7 +2,7 @@ package com.WearWeather.wear.domain.post.dto.request;
 
 import com.WearWeather.wear.domain.post.entity.GenderFilter;
 import com.WearWeather.wear.domain.post.entity.SortType;
-import com.WearWeather.wear.global.validation.Enum;
+import com.WearWeather.wear.global.validation.ValidEnum;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
@@ -26,8 +26,8 @@ public record PostsByFiltersRequest (
     List<Long> weatherTagIds,
     List<Long> temperatureTagIds,
 
-    @Enum(target = GenderFilter.class, message = "올바른 성별 필터 값을 입력해주세요.")
-    String gender,
+    @ValidEnum(enumClass = GenderFilter.class, message = "올바른 성별 필터 값을 입력해주세요.")
+    GenderFilter gender,
 
     @NotNull(message = "정렬 방법은 필수입니다.")
     SortType sort

--- a/src/main/java/com/WearWeather/wear/global/exception/GlobalExceptionHandler/GlobalExceptionHandler.java
+++ b/src/main/java/com/WearWeather/wear/global/exception/GlobalExceptionHandler/GlobalExceptionHandler.java
@@ -12,6 +12,8 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
+    private final String VALIDATION_ERROR = "VALIDATION_ERROR";
+
     @ExceptionHandler({CustomException.class})
     public ResponseEntity<CustomErrorResponse> handleCustomException(CustomException ex) {
         CustomErrorResponse errorResponse = new CustomErrorResponse(
@@ -21,13 +23,13 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(errorResponse, ex.getHttpStatus());
     }
 
-    @ExceptionHandler(MethodArgumentNotValidException.class)
+    @ExceptionHandler({MethodArgumentNotValidException.class})
     protected ResponseEntity<CustomErrorResponse> handleException(MethodArgumentNotValidException ex) {
 
         FieldError fieldError = ex.getBindingResult().getFieldErrors().get(0);
         CustomErrorResponse errorResponse = new CustomErrorResponse(
             HttpStatus.BAD_REQUEST.name(),
-            "VALIDATION_ERROR",
+            VALIDATION_ERROR,
             fieldError.getDefaultMessage()
         );
         return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);

--- a/src/main/java/com/WearWeather/wear/global/validation/EnumValidator.java
+++ b/src/main/java/com/WearWeather/wear/global/validation/EnumValidator.java
@@ -3,20 +3,19 @@ package com.WearWeather.wear.global.validation;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
 
-public class EnumValidator implements ConstraintValidator<Enum, String> {
-  private Enum annotation;
-
+public class EnumValidator implements ConstraintValidator<ValidEnum, Enum> {
+  private ValidEnum annotation;
   @Override
-  public void initialize(Enum constraintAnnotation) {
+  public void initialize(ValidEnum constraintAnnotation) {
     this.annotation = constraintAnnotation;
   }
 
   @Override
-  public boolean isValid(String value, ConstraintValidatorContext context) {
-    Object[] enumValues = this.annotation.target().getEnumConstants();
+  public boolean isValid(Enum value, ConstraintValidatorContext context) {
+    Object[] enumValues = this.annotation.enumClass().getEnumConstants();
     if (enumValues != null) {
       for (Object enumValue : enumValues) {
-        if (value.equals(enumValue.toString())) {
+        if (value == enumValue) {
           return true;
         }
       }

--- a/src/main/java/com/WearWeather/wear/global/validation/EnumValidator.java
+++ b/src/main/java/com/WearWeather/wear/global/validation/EnumValidator.java
@@ -3,7 +3,7 @@ package com.WearWeather.wear.global.validation;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
 
-public class EnumValidator implements ConstraintValidator<ValidEnum, Enum> {
+public class EnumValidator implements ConstraintValidator<ValidEnum, String> {
   private ValidEnum annotation;
   @Override
   public void initialize(ValidEnum constraintAnnotation) {
@@ -11,11 +11,11 @@ public class EnumValidator implements ConstraintValidator<ValidEnum, Enum> {
   }
 
   @Override
-  public boolean isValid(Enum value, ConstraintValidatorContext context) {
+  public boolean isValid(String value, ConstraintValidatorContext context) {
     Object[] enumValues = this.annotation.enumClass().getEnumConstants();
     if (enumValues != null) {
       for (Object enumValue : enumValues) {
-        if (value == enumValue) {
+        if (value.equals(enumValue.toString())) {
           return true;
         }
       }

--- a/src/main/java/com/WearWeather/wear/global/validation/ValidEnum.java
+++ b/src/main/java/com/WearWeather/wear/global/validation/ValidEnum.java
@@ -10,12 +10,12 @@ import java.lang.annotation.Target;
 @Constraint(validatedBy = {EnumValidator.class})
 @Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER})
 @Retention(RetentionPolicy.RUNTIME)
-public @interface Enum {
+public @interface ValidEnum {
   String message() default "올바르지 않은 값입니다.";
 
   Class<?>[] groups() default {};
 
   Class<? extends Payload>[] payload() default {};
 
-  Class<? extends java.lang.Enum<?>> target();
+  Class<? extends java.lang.Enum<?>> enumClass();
 }


### PR DESCRIPTION
## 개요
성별 필터를 추가한 게시글 작성 및 게시글 필터에서의 오류 수정

## 문제점
게시글 작성에서는 Enum 클래스로 gender 값을 받고,
게시글 필터에서는 String으로 gender값을 받아
두 필터의 불일치로 인해 @Enum 어노테이션의 오류 발생

## 개선
@Enum 어노테이션을 통해 타켓으로 설정한 enum 클래스 내의 값인지 검증하므로
request 내 성별 필터를 string으로 받도록 수정하고,
@EnumValidator에서 enum 내의 값과 reqeust의 값을 string으로 비교하여 검증한다.