### PR TITLE
나의 게시글 조회 새로고침 시 빈 배열 반환하는 문제

### DIFF
--- a/src/main/java/com/WearWeather/wear/global/config/SecurityConfig.java
+++ b/src/main/java/com/WearWeather/wear/global/config/SecurityConfig.java
@@ -67,6 +67,8 @@ public class SecurityConfig {
               "/basic-location", "/location/**", "/regions","/users/delete-reasons", "/weather/**"
             ).permitAll()
             .requestMatchers(HttpMethod.GET, "/posts/top-liked").permitAll()
+            .requestMatchers(HttpMethod.GET, "/posts/me").authenticated()
+
             .requestMatchers(HttpMethod.GET, "/posts").permitAll()
             .requestMatchers(HttpMethod.POST, "/posts/search").permitAll()
             .requestMatchers(HttpMethod.GET, "/posts/{postId}").permitAll()


### PR DESCRIPTION
문제
---
나의 게시글 조회 페이지에서 새로고침 시 나의 게시글이 아닌 빈 배열을 반환하고 있다.

원인
---
SecurityConfig 내 .requestMatchers(HttpMethod.GET,"/posts/{postId}").permitAll() 과정에서 "posts/me"까지 허용되고 있다.

해결
---
posts/me api는 인증이 수행되도록 설정 추가