### PR TITLE
User 도메인 리펙토링 - Facade Pattern

### DIFF
--- a/src/main/java/com/WearWeather/wear/domain/oauth/infrastructure/kakao/service/KakaoUserService.java
+++ b/src/main/java/com/WearWeather/wear/domain/oauth/infrastructure/kakao/service/KakaoUserService.java
@@ -1,9 +1,13 @@
 package com.WearWeather.wear.domain.oauth.infrastructure.kakao.service;
 
 import com.WearWeather.wear.domain.oauth.infrastructure.kakao.KaKaoUserInfo;
+import com.WearWeather.wear.domain.oauth.infrastructure.kakao.dto.KakaoUserDto;
 import com.WearWeather.wear.domain.oauth.infrastructure.kakao.entity.KakaoUser;
 import com.WearWeather.wear.domain.oauth.infrastructure.kakao.repository.KakaoUserRepository;
+import com.WearWeather.wear.domain.oauth.service.RequestOAuthUnlinkService;
 import com.WearWeather.wear.domain.user.entity.User;
+import com.WearWeather.wear.global.exception.CustomException;
+import com.WearWeather.wear.global.exception.ErrorCode;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -13,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class KakaoUserService {
 
+    private final RequestOAuthUnlinkService requestOAuthUnlinkService;
     private final KakaoUserRepository kakaoUserRepository;
 
     @Transactional
@@ -36,4 +41,11 @@ public class KakaoUserService {
         kakaoUserRepository.delete(kakaoUser);
     }
 
+    public void unlinkOauth(Long userId) {
+        KakaoUser kakaoUser = getKakaoUserByUserId(userId)
+          .orElseThrow(() -> new CustomException(ErrorCode.KAKAO_USER_NOT_FOUND));
+
+        requestOAuthUnlinkService.request(KakaoUserDto.of(kakaoUser));
+        deleteKakaoUser(kakaoUser);
+    }
 }

--- a/src/main/java/com/WearWeather/wear/domain/user/controller/UserController.java
+++ b/src/main/java/com/WearWeather/wear/domain/user/controller/UserController.java
@@ -5,6 +5,7 @@ import com.WearWeather.wear.domain.user.dto.response.FindUserEmailResponse;
 import com.WearWeather.wear.domain.user.dto.response.NicknameDuplicateCheckResponse;
 import com.WearWeather.wear.domain.user.dto.response.UserIdForPasswordUpdateResponse;
 import com.WearWeather.wear.domain.user.dto.response.UserInfoResponse;
+import com.WearWeather.wear.domain.user.facade.UserDeleteFacade;
 import com.WearWeather.wear.domain.user.service.UserService;
 import com.WearWeather.wear.global.common.ResponseMessage;
 import com.WearWeather.wear.global.common.dto.ResponseCommonDTO;
@@ -26,6 +27,7 @@ import org.springframework.web.bind.annotation.*;
 public class UserController {
 
     private final UserService userService;
+    private final UserDeleteFacade userDeleteFacade;
 
     @PostMapping("/register")
     public ResponseEntity<ResponseCommonDTO> signup(@Valid @RequestBody RegisterUserRequest request) {
@@ -55,24 +57,18 @@ public class UserController {
 
     @PatchMapping("/password")
     public ResponseEntity<ResponseCommonDTO> modifyPassword(@Valid @RequestBody ModifyUserPasswordRequest request) {
-
         userService.modifyPassword(request);
         return ResponseEntity.ok(new ResponseCommonDTO(true, ResponseMessage.MODIFY_PASSWORD));
     }
 
     @GetMapping("/me")
     public ResponseEntity<UserInfoResponse> getUserInfo(@LoggedInUser Long userId) {
-//        Long userId = optionalUserId.orElseThrow(() -> new CustomException(ErrorCode.SERVER_ERROR));
-
         UserInfoResponse userInfoResponse = userService.getUserInfo(userId);
         return ResponseEntity.ok(userInfoResponse);
     }
 
     @PatchMapping("/me")
     public ResponseEntity<ResponseCommonDTO> modifyUserInfo(@LoggedInUser Long userId, @Valid @RequestBody ModifyUserInfoRequest request) {
-
-//        Long userId = optionalUserId.orElseThrow(() -> new CustomException(ErrorCode.SERVER_ERROR));
-
         userService.modifyUserInfo(
             userId, request.getPassword(), request.getNickname());
         return ResponseEntity.ok(new ResponseCommonDTO(true, ResponseMessage.MODIFY_USERINFO));
@@ -80,8 +76,7 @@ public class UserController {
 
     @DeleteMapping
     public ResponseEntity<ResponseCommonDTO> deleteUser(@LoggedInUser Long userId,@RequestParam @NotBlank String deleteReason) {
-
-        userService.deleteUser(userId, deleteReason);
+        userDeleteFacade.deleteUser(userId, deleteReason);
         return ResponseEntity.ok(new ResponseCommonDTO(true, ResponseMessage.SUCCESS_DELETE_USER));
     }
 

--- a/src/main/java/com/WearWeather/wear/domain/user/facade/UserDeleteFacade.java
+++ b/src/main/java/com/WearWeather/wear/domain/user/facade/UserDeleteFacade.java
@@ -1,0 +1,30 @@
+package com.WearWeather.wear.domain.user.facade;
+
+import com.WearWeather.wear.domain.oauth.infrastructure.kakao.service.KakaoUserService;
+import com.WearWeather.wear.domain.user.entity.User;
+import com.WearWeather.wear.domain.user.enums.DeleteReason;
+import com.WearWeather.wear.domain.user.service.UserDeleteService;
+import com.WearWeather.wear.domain.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Component
+public class UserDeleteFacade {
+
+    private final UserService userService;
+    private final UserDeleteService userDeleteService;
+    private final KakaoUserService kakaoUserService;
+
+    @Transactional
+    public void deleteUser(Long userId, String reason) {
+        DeleteReason deleteReason = userDeleteService.getDeleteReason(reason);
+        User user = userService.softDelete(userId);
+        userDeleteService.save(user, deleteReason);
+        if (user.isSocial()) {
+            kakaoUserService.unlinkOauth(userId);
+        }
+    }
+
+}

--- a/src/main/java/com/WearWeather/wear/domain/user/service/UserDeleteService.java
+++ b/src/main/java/com/WearWeather/wear/domain/user/service/UserDeleteService.java
@@ -6,6 +6,7 @@ import com.WearWeather.wear.domain.user.entity.UserDelete;
 import com.WearWeather.wear.domain.user.repository.UserDeleteRepository;
 import com.WearWeather.wear.global.exception.CustomException;
 import com.WearWeather.wear.global.exception.ErrorCode;
+import java.util.Arrays;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -34,6 +35,13 @@ public class UserDeleteService {
 
     public Optional<UserDelete> getUserDeleteByUserId(Long userId){
         return userDeleteRepository.findByUserId(userId);
+    }
+
+    public DeleteReason getDeleteReason(String reason) {
+        return Arrays.stream(DeleteReason.values())
+          .filter(deleteReason -> deleteReason.getDescription().equals(reason))
+          .findFirst()
+          .orElseThrow(() -> new CustomException(ErrorCode.INVALID_DELETE_REASON));
     }
 
 }

--- a/src/main/java/com/WearWeather/wear/domain/user/service/UserService.java
+++ b/src/main/java/com/WearWeather/wear/domain/user/service/UserService.java
@@ -1,21 +1,16 @@
 package com.WearWeather.wear.domain.user.service;
 
-import com.WearWeather.wear.domain.oauth.infrastructure.kakao.dto.KakaoUserDto;
-import com.WearWeather.wear.domain.oauth.infrastructure.kakao.entity.KakaoUser;
 import com.WearWeather.wear.domain.oauth.infrastructure.kakao.service.KakaoUserService;
 import com.WearWeather.wear.domain.oauth.service.RequestOAuthUnlinkService;
-import com.WearWeather.wear.domain.user.dto.request.DeleteReasonRequest;
 import com.WearWeather.wear.domain.user.dto.request.ModifyUserPasswordRequest;
 import com.WearWeather.wear.domain.user.dto.request.RegisterUserRequest;
 import com.WearWeather.wear.domain.user.dto.response.UserIdForPasswordUpdateResponse;
 import com.WearWeather.wear.domain.user.dto.response.UserInfoResponse;
-import com.WearWeather.wear.domain.user.enums.DeleteReason;
 import com.WearWeather.wear.domain.user.entity.User;
 import com.WearWeather.wear.domain.user.repository.UserNicknameMapping;
 import com.WearWeather.wear.domain.user.repository.UserRepository;
 import com.WearWeather.wear.global.exception.CustomException;
 import com.WearWeather.wear.global.exception.ErrorCode;
-import java.util.Arrays;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -140,27 +135,9 @@ public class UserService {
             .orElse("탈퇴한 사용자");
     }
 
-    @Transactional
-    public void deleteUser(Long userId, String reason) {
-        DeleteReason deleteReason = getDeleteReason(reason);
+    public User softDelete(Long userId) {
         User user = getUser(userId);
         user.updateIsDelete();
-
-        userDeleteService.save(user, deleteReason);
-
-        if (user.isSocial()) {
-            KakaoUser kakaoUser = kakaoUserService.getKakaoUserByUserId(userId)
-                .orElseThrow(() -> new CustomException(ErrorCode.KAKAO_USER_NOT_FOUND));
-
-            requestOAuthUnlinkService.request(KakaoUserDto.of(kakaoUser));
-            kakaoUserService.deleteKakaoUser(kakaoUser);
-        }
-    }
-
-    private DeleteReason getDeleteReason(String reason) {
-        return Arrays.stream(DeleteReason.values())
-            .filter(deleteReason -> deleteReason.getDescription().equals(reason))
-            .findFirst()
-            .orElseThrow(() -> new CustomException(ErrorCode.INVALID_DELETE_REASON));
+        return user;
     }
 }

--- a/src/test/java/com/WearWeather/wear/domain/user/UserServiceTest.java
+++ b/src/test/java/com/WearWeather/wear/domain/user/UserServiceTest.java
@@ -17,12 +17,11 @@ import com.WearWeather.wear.domain.oauth.infrastructure.kakao.dto.KakaoUserDto;
 import com.WearWeather.wear.domain.oauth.infrastructure.kakao.entity.KakaoUser;
 import com.WearWeather.wear.domain.oauth.infrastructure.kakao.service.KakaoUserService;
 import com.WearWeather.wear.domain.oauth.service.RequestOAuthUnlinkService;
-import com.WearWeather.wear.domain.user.dto.request.DeleteReasonRequest;
 import com.WearWeather.wear.domain.user.dto.request.ModifyUserPasswordRequest;
 import com.WearWeather.wear.domain.user.dto.request.RegisterUserRequest;
 import com.WearWeather.wear.domain.user.dto.response.UserInfoResponse;
 import com.WearWeather.wear.domain.user.entity.User;
-import com.WearWeather.wear.domain.user.enums.DeleteReason;
+import com.WearWeather.wear.domain.user.facade.UserDeleteFacade;
 import com.WearWeather.wear.domain.user.repository.UserRepository;
 import com.WearWeather.wear.domain.user.service.UserDeleteService;
 import com.WearWeather.wear.domain.user.service.UserService;
@@ -44,6 +43,9 @@ public class UserServiceTest {
 
     @InjectMocks
     UserService userService;
+
+    @InjectMocks
+    UserDeleteFacade userDeleteFacade;
 
     @Mock
     UserDeleteService userDeleteService;
@@ -90,8 +92,8 @@ public class UserServiceTest {
         when(userRepository.existsByEmailAndIsDeleteFalse(UserFixture.email)).thenReturn(true);
 
         assertThatThrownBy(() -> userService.checkDuplicatedUserEmail(UserFixture.email))
-            .isInstanceOf(CustomException.class)
-            .hasFieldOrPropertyWithValue("errorCode", ErrorCode.EMAIL_ALREADY_EXIST);
+          .isInstanceOf(CustomException.class)
+          .hasFieldOrPropertyWithValue("errorCode", ErrorCode.EMAIL_ALREADY_EXIST);
 
     }
 
@@ -102,8 +104,8 @@ public class UserServiceTest {
         when(userRepository.existsByNicknameAndIsDeleteFalse(UserFixture.nickname)).thenReturn(true);
 
         assertThatThrownBy(() -> userService.checkDuplicatedUserNickName(UserFixture.nickname))
-            .isInstanceOf(CustomException.class)
-            .hasFieldOrPropertyWithValue("errorCode", ErrorCode.NICKNAME_ALREADY_EXIST);
+          .isInstanceOf(CustomException.class)
+          .hasFieldOrPropertyWithValue("errorCode", ErrorCode.NICKNAME_ALREADY_EXIST);
 
     }
 
@@ -125,8 +127,8 @@ public class UserServiceTest {
     public void findEmailNotMatchRequestTest() {
 
         assertThatThrownBy(() -> userService.findUserEmail(UserFixture.name, UserFixture.nickname))
-            .isInstanceOf(CustomException.class)
-            .hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOT_MATCH_EMAIL);
+          .isInstanceOf(CustomException.class)
+          .hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOT_MATCH_EMAIL);
 
     }
 
@@ -137,8 +139,8 @@ public class UserServiceTest {
         when(userRepository.findByEmailAndNameAndNicknameAndIsDeleteFalse(UserFixture.email, UserFixture.name, UserFixture.nickname)).thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> userService.findUserPassword(UserFixture.email, UserFixture.name, UserFixture.nickname))
-            .isInstanceOf(CustomException.class)
-            .hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOT_EXIST_USER);
+          .isInstanceOf(CustomException.class)
+          .hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOT_EXIST_USER);
 
     }
 
@@ -174,10 +176,10 @@ public class UserServiceTest {
         when(passwordEncoder.encode(newPassword)).thenReturn(newPassword);
 
         doThrow(new CustomException(ErrorCode.FAIL_UPDATE_PASSWORD))
-            .when(user).updatePassword(anyString(), anyBoolean());
+          .when(user).updatePassword(anyString(), anyBoolean());
 
         CustomException exception = assertThrows(CustomException.class, () ->
-            userService.modifyPassword(request));
+          userService.modifyPassword(request));
         assertEquals(ErrorCode.FAIL_UPDATE_PASSWORD, exception.getErrorCode());
     }
 
@@ -197,10 +199,10 @@ public class UserServiceTest {
         when(userRepository.findById(userId)).thenReturn(Optional.of(user));
 
         doThrow(new CustomException(ErrorCode.SOCIAL_ACCOUNT_CANNOT_BE_MODIFIED))
-            .when(user).updatePassword(anyString(), eq(true));
+          .when(user).updatePassword(anyString(), eq(true));
 
         CustomException exception = assertThrows(CustomException.class, () ->
-            userService.modifyPassword(request));
+          userService.modifyPassword(request));
 
         assertEquals(ErrorCode.FAIL_UPDATE_PASSWORD, exception.getErrorCode());
     }
@@ -210,7 +212,7 @@ public class UserServiceTest {
     public void getUserInfoTest() {
 
         User user = UserFixture.createUser();
-        UserInfoResponse response = new UserInfoResponse(UserFixture.email, UserFixture.name, UserFixture.nickname,UserFixture.isSocial);
+        UserInfoResponse response = new UserInfoResponse(UserFixture.email, UserFixture.name, UserFixture.nickname, UserFixture.isSocial);
 
         when(userRepository.findByUserIdAndIsDeleteFalse(UserFixture.userId)).thenReturn(Optional.of(user));
 
@@ -228,7 +230,7 @@ public class UserServiceTest {
         when(userRepository.findByUserIdAndIsDeleteFalse(UserFixture.userId)).thenReturn(Optional.empty());
 
         CustomException exception = assertThrows(CustomException.class, () ->
-            userService.getUserInfo(UserFixture.userId));
+          userService.getUserInfo(UserFixture.userId));
         assertEquals(ErrorCode.NOT_EXIST_USER, exception.getErrorCode());
     }
 
@@ -254,7 +256,7 @@ public class UserServiceTest {
         when(userRepository.findByUserIdAndIsDeleteFalse(UserFixture.userId)).thenReturn(Optional.empty());
 
         CustomException exception = assertThrows(CustomException.class, () ->
-            userService.modifyUserInfo(UserFixture.userId, UserFixture.password, UserFixture.nickname));
+          userService.modifyUserInfo(UserFixture.userId, UserFixture.password, UserFixture.nickname));
         assertEquals(ErrorCode.NOT_EXIST_USER, exception.getErrorCode());
     }
 
@@ -268,101 +270,12 @@ public class UserServiceTest {
         when(passwordEncoder.encode(UserFixture.password)).thenReturn(UserFixture.password);
 
         doThrow(new CustomException(ErrorCode.INVALID_NICKNAME))
-            .when(user).updateUserInfo(anyString(), anyString(), anyBoolean());
+          .when(user).updateUserInfo(anyString(), anyString(), anyBoolean());
 
         CustomException exception = assertThrows(CustomException.class, () ->
-            userService.modifyUserInfo(UserFixture.userId, UserFixture.password, UserFixture.nickname));
+          userService.modifyUserInfo(UserFixture.userId, UserFixture.password, UserFixture.nickname));
 
         assertEquals(ErrorCode.FAIL_UPDATE_USER_INFO, exception.getErrorCode());
 
-    }
-
-    @Test
-    @DisplayName("정상 테스트 : 일반 사용자가 회원 탈퇴에 성공한다")
-    public void deleteUserSuccessTest() {
-        // given
-        Long userId = 1L;
-        String deleteReason = "오류가 잦아요";
-
-        User user = mock(User.class);
-        DeleteReason enumReason = DeleteReason.ERROR_FREQUENT;
-
-        when(userRepository.findByUserIdAndIsDeleteFalse(userId)).thenReturn(Optional.of(user));
-
-        // when
-        userService.deleteUser(userId, deleteReason);
-
-        // then
-        verify(user).updateIsDelete();
-        verify(userDeleteService).save(user, enumReason);
-    }
-
-    @Test
-    @DisplayName("예외 테스트 : 존재하지 않는 사용자 정보로 회원 탈퇴를 시도하여 실패한다.")
-    public void deleteUserNotFoundTest() {
-        // given
-        Long userId = 1L;
-        String deleteReason = "오류가 잦아요";
-
-        when(userRepository.findByUserIdAndIsDeleteFalse(userId)).thenReturn(Optional.empty());
-
-        // when & then
-        assertThatThrownBy(() -> userService.deleteUser(userId, deleteReason))
-            .isInstanceOf(CustomException.class)
-            .hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOT_EXIST_USER);
-    }
-
-    @Test
-    @DisplayName("예외 테스트 : 유효하지 않은 탈퇴 이유 값으로 회원 탈퇴를 시도하여 실패한다.")
-    public void deleteUserWithInvalidReasonTest() {
-        // given
-        Long userId = 1L;
-        String invalidReason = "유효하지 않은 탈퇴 이유";
-
-        // when & then
-        assertThatThrownBy(() -> userService.deleteUser(userId, invalidReason))
-            .isInstanceOf(CustomException.class)
-            .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_DELETE_REASON);
-    }
-
-    @Test
-    @DisplayName("정상 테스트 : 소셜 로그인 사용자가 회원 탈퇴를 성공한다")
-    public void deleteSocialUserTest() {
-        // given
-        Long userId = 1L;
-        String deleteReason = "서비스 기능이 미흡해요";
-
-        User user = mock(User.class);
-        DeleteReason enumReason = DeleteReason.POOR_FUNCTIONALITY;
-
-        when(userRepository.findByUserIdAndIsDeleteFalse(userId)).thenReturn(Optional.of(user));
-        when(user.isSocial()).thenReturn(true);
-        when(kakaoUserService.getKakaoUserByUserId(userId)).thenReturn(Optional.of(kakaoUser));
-
-        // when
-        userService.deleteUser(userId, deleteReason);
-
-        // then
-        verify(user).updateIsDelete();
-        verify(userDeleteService).save(user, enumReason);
-        verify(kakaoUserService).deleteKakaoUser(kakaoUser);
-    }
-
-    @Test
-    @DisplayName("예외 테스트 : 소셜 로그인 사용자 정보가 없어 회원 탈퇴에 실패한다")
-    public void deleteSocialUserNotFoundTest() {
-        // given
-        Long userId = 1L;
-        String deleteReason = "서비스 기능이 미흡해요";
-
-        User user = mock(User.class);
-        when(userRepository.findByUserIdAndIsDeleteFalse(userId)).thenReturn(Optional.of(user));
-        when(user.isSocial()).thenReturn(true);
-        when(kakaoUserService.getKakaoUserByUserId(userId)).thenReturn(Optional.empty());
-
-        // when & then
-        assertThatThrownBy(() -> userService.deleteUser(userId, deleteReason))
-            .isInstanceOf(CustomException.class)
-            .hasFieldOrPropertyWithValue("errorCode", ErrorCode.KAKAO_USER_NOT_FOUND);
     }
 }

--- a/src/test/java/com/WearWeather/wear/domain/user/facade/UserDeleteFacadeTest.java
+++ b/src/test/java/com/WearWeather/wear/domain/user/facade/UserDeleteFacadeTest.java
@@ -1,0 +1,111 @@
+package com.WearWeather.wear.domain.user.facade;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.WearWeather.wear.domain.oauth.infrastructure.kakao.service.KakaoUserService;
+import com.WearWeather.wear.domain.user.entity.User;
+import com.WearWeather.wear.domain.user.enums.DeleteReason;
+import com.WearWeather.wear.domain.user.service.UserDeleteService;
+import com.WearWeather.wear.domain.user.service.UserService;
+import com.WearWeather.wear.global.exception.CustomException;
+import com.WearWeather.wear.global.exception.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@DisplayName("UserDeleteFacade 테스트")
+@ExtendWith(MockitoExtension.class)
+public class UserDeleteFacadeTest {
+
+    @InjectMocks
+    UserDeleteFacade userDeleteFacade;
+
+    @Mock
+    UserService userService;
+
+    @Mock
+    UserDeleteService userDeleteService;
+
+    @Mock
+    KakaoUserService kakaoUserService;
+
+    @Mock
+    User user;
+
+    @Test
+    @DisplayName("정상 테스트: 일반 사용자가 회원 탈퇴에 성공한다")
+    public void deleteUserSuccessTest() {
+        // given
+        Long userId = 1L;
+        String deleteReason = "오류가 잦아요";
+        DeleteReason enumReason = DeleteReason.ERROR_FREQUENT;
+
+        when(userService.softDelete(userId)).thenReturn(user);
+        when(userDeleteService.getDeleteReason(deleteReason)).thenReturn(enumReason);
+
+        // when
+        userDeleteFacade.deleteUser(userId, deleteReason);
+
+        // then
+        verify(userService).softDelete(userId);
+        verify(userDeleteService).save(user, enumReason);
+    }
+
+    @Test
+    @DisplayName("예외 테스트: 존재하지 않는 사용자 정보로 회원 탈퇴를 시도하여 실패한다.")
+    public void deleteUserNotFoundTest() {
+        // given
+        Long userId = 1L;
+        String deleteReason = "오류가 잦아요";
+
+        when(userService.softDelete(userId))
+          .thenThrow(new CustomException(ErrorCode.NOT_EXIST_USER));
+
+        // when & then
+        assertThatThrownBy(() -> userDeleteFacade.deleteUser(userId, deleteReason))
+          .isInstanceOf(CustomException.class)
+          .hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOT_EXIST_USER);
+    }
+
+    @Test
+    @DisplayName("예외 테스트: 유효하지 않은 탈퇴 이유 값으로 회원 탈퇴를 시도하여 실패한다.")
+    public void deleteUserWithInvalidReasonTest() {
+        // given
+        Long userId = 1L;
+        String invalidReason = "유효하지 않은 탈퇴 이유";
+
+        when(userDeleteService.getDeleteReason(invalidReason))
+          .thenThrow(new CustomException(ErrorCode.INVALID_DELETE_REASON));
+
+        // when & then
+        assertThatThrownBy(() -> userDeleteFacade.deleteUser(userId, invalidReason))
+          .isInstanceOf(CustomException.class)
+          .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_DELETE_REASON);
+    }
+
+    @Test
+    @DisplayName("정상 테스트: 소셜 로그인 사용자가 회원 탈퇴에 성공한다")
+    public void deleteSocialUserTest() {
+        // given
+        Long userId = 1L;
+        String deleteReason = "서비스 기능이 미흡해요";
+        DeleteReason enumReason = DeleteReason.POOR_FUNCTIONALITY;
+
+        when(userService.softDelete(userId)).thenReturn(user);
+        when(userDeleteService.getDeleteReason(deleteReason)).thenReturn(enumReason);
+        when(user.isSocial()).thenReturn(true);
+
+        // when
+        userDeleteFacade.deleteUser(userId, deleteReason);
+
+        // then
+        verify(userService).softDelete(userId);
+        verify(userDeleteService).save(user, enumReason);
+        verify(kakaoUserService).unlinkOauth(userId);
+    }
+}


### PR DESCRIPTION
문제
---
- UserService에서 너무 많은 의존성을 가지고 있어서 변경에 용이하지 않고 가독성이 좋지 않다.
- 각 클래스 책임에 맞게 않게 로직이 작성된 부분이 많다.

문제 해결 방법
---
- 의존성 문제 해결을 위한 Facade 패턴을 도입하여 각 기능에 맞는 Facade 클래스를 생성하여 의존성을 분리하였습니다.
  - User와 관련된 데이터에 대한 로직이 실행되는 API는 UserService에서 호출
  - User와 다른 도메인과 관련된 로직이 실행되는 API에 대해선 흐름 파악을 위해 Facade도입