### PR TITLE
AT 쿠키로 보내주는 것으로 수정

### DIFF
--- a/src/main/java/com/WearWeather/wear/domain/auth/dto/response/TokenResponse.java
+++ b/src/main/java/com/WearWeather/wear/domain/auth/dto/response/TokenResponse.java
@@ -8,8 +8,16 @@ import lombok.Getter;
 @Getter
 @Builder
 @AllArgsConstructor
-@Data
 public class TokenResponse {
 
     private final String accessToken;
+    private final String refreshToken;
+
+    public static TokenResponse of(String accessToken, String refreshToken) {
+        return TokenResponse.builder()
+          .accessToken(accessToken)
+          .refreshToken(refreshToken)
+          .build();
+    }
 }
+

--- a/src/main/java/com/WearWeather/wear/domain/auth/facade/LoginFacade.java
+++ b/src/main/java/com/WearWeather/wear/domain/auth/facade/LoginFacade.java
@@ -3,10 +3,13 @@ package com.WearWeather.wear.domain.auth.facade;
 
 import com.WearWeather.wear.domain.auth.dto.request.LoginRequest;
 import com.WearWeather.wear.domain.auth.dto.response.LoginResponse;
+import com.WearWeather.wear.domain.auth.dto.response.TokenResponse;
 import com.WearWeather.wear.domain.auth.provider.AuthenticationProvider;
 import com.WearWeather.wear.domain.user.entity.User;
 import com.WearWeather.wear.domain.user.service.UserService;
+import com.WearWeather.wear.global.jwt.JwtCookieManager;
 import com.WearWeather.wear.global.jwt.TokenProvider;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
@@ -19,10 +22,12 @@ public class LoginFacade {
     private final TokenProvider tokenProvider;
     private final UserService userService;
 
-    public LoginResponse checkLogin(LoginRequest request) {
+    public TokenResponse checkLogin(LoginRequest request) {
         User user = userService.getUserByEmail(request.getEmail());
         Authentication authentication = authenticationProvider.authenticateWithCredentials(request.getEmail(), request.getPassword());
         String accessToken = tokenProvider.createAccessToken(authentication);
-        return LoginResponse.of(user, accessToken);
+        String refreshToken = tokenProvider.createRefreshToken(user.getUserId());
+
+        return TokenResponse.of(accessToken, refreshToken);
     }
 }

--- a/src/main/java/com/WearWeather/wear/domain/auth/facade/ReissueFacade.java
+++ b/src/main/java/com/WearWeather/wear/domain/auth/facade/ReissueFacade.java
@@ -21,16 +21,15 @@ public class ReissueFacade {
     private final AuthenticationProvider authenticationProvider;
     private final TokenProvider tokenProvider;
 
-    public TokenResponse reissue(String refreshToken) {
+    public String reissue(String refreshToken) {
         Long userId = tokenProvider.getRefreshTokenInfo(refreshToken);
         String savedRefreshToken = redisService.getValues(userId);
         validateRefreshToken(savedRefreshToken, refreshToken);
 
         User user = userService.getUser(userId);
         Authentication authentication = authenticationProvider.createAuthenticatedToken(user);
-        String newAccessToken = tokenProvider.createAccessToken(authentication);
 
-        return new TokenResponse(newAccessToken);
+        return tokenProvider.createAccessToken(authentication);
     }
 
     private void validateRefreshToken(String savedRefreshToken, String refreshToken) {

--- a/src/main/java/com/WearWeather/wear/domain/oauth/controller/OAuthController.java
+++ b/src/main/java/com/WearWeather/wear/domain/oauth/controller/OAuthController.java
@@ -1,6 +1,7 @@
 package com.WearWeather.wear.domain.oauth.controller;
 
 import com.WearWeather.wear.domain.auth.dto.response.LoginResponse;
+import com.WearWeather.wear.domain.auth.dto.response.TokenResponse;
 import com.WearWeather.wear.domain.oauth.infrastructure.kakao.KakaoLoginParam;
 import com.WearWeather.wear.domain.oauth.service.OAuthLoginService;
 import com.WearWeather.wear.global.jwt.JwtCookieManager;
@@ -28,13 +29,11 @@ public class OAuthController {
     private final JwtCookieManager jwtCookieManager;
 
     @GetMapping("/kakao")
-    public ResponseEntity<LoginResponse> kakaoLogin(@RequestParam("code") String code, HttpServletResponse response) {
+    public ResponseEntity<Void> kakaoLogin(@RequestParam("code") String code, HttpServletResponse response) {
         KakaoLoginParam param = new KakaoLoginParam(code);
-        LoginResponse loginResponse = oAuthLoginService.login(param);
-
-        jwtCookieManager.saveAccessTokenToCookie(response, loginResponse.getAccessToken());
-        String refreshToken = tokenProvider.renewRefreshToken(loginResponse.getAccessToken());
-        jwtCookieManager.saveRefreshTokenToCookie(response, refreshToken);
-        return new ResponseEntity<>(loginResponse, HttpStatus.OK);
+        TokenResponse tokenResponse  = oAuthLoginService.login(param);
+        jwtCookieManager.saveAccessTokenToCookie(response, tokenResponse.getAccessToken());
+        jwtCookieManager.saveRefreshTokenToCookie(response, tokenResponse.getRefreshToken());
+        return new ResponseEntity<>(HttpStatus.OK);
     }
 }

--- a/src/main/java/com/WearWeather/wear/domain/oauth/service/OAuthLoginService.java
+++ b/src/main/java/com/WearWeather/wear/domain/oauth/service/OAuthLoginService.java
@@ -1,6 +1,7 @@
 package com.WearWeather.wear.domain.oauth.service;
 
 import com.WearWeather.wear.domain.auth.dto.response.LoginResponse;
+import com.WearWeather.wear.domain.auth.dto.response.TokenResponse;
 import com.WearWeather.wear.domain.oauth.domain.oauth.OAuthLoginParams;
 import com.WearWeather.wear.domain.oauth.domain.oauth.OAuthUserInfo;
 import com.WearWeather.wear.domain.oauth.infrastructure.kakao.KaKaoUserInfo;
@@ -32,7 +33,7 @@ public class OAuthLoginService {
     private final PasswordEncoder passwordEncoder;
     private final KakaoUserService kakaoUserService;
 
-    public LoginResponse login(OAuthLoginParams params) {
+    public TokenResponse login(OAuthLoginParams params) {
         OAuthUserInfo oAuthUserInfo = requestOAuthInfoService.request(params);
         User user = findOrRegisterUser(oAuthUserInfo);
 
@@ -47,8 +48,9 @@ public class OAuthLoginService {
         );
 
         String accessToken = tokenProvider.createAccessToken(authentication);
+        String refreshToken = tokenProvider.createRefreshToken(user.getUserId());
 
-        return LoginResponse.of(user, accessToken);
+        return TokenResponse.of(accessToken, refreshToken);
     }
 
     private User findOrRegisterUser(OAuthUserInfo oAuthUserInfo) {

--- a/src/main/java/com/WearWeather/wear/global/jwt/JwtCookieManager.java
+++ b/src/main/java/com/WearWeather/wear/global/jwt/JwtCookieManager.java
@@ -1,0 +1,54 @@
+package com.WearWeather.wear.global.jwt;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtCookieManager {
+
+    private static final String ACCESS_TOKEN_COOKIE_NAME = "accessToken";
+    private static final String REFRESH_TOKEN_COOKIE_NAME = "refreshToken";
+    private static final String DOMAIN = "lookattheweather.store";
+
+    private static final int ACCESS_TOKEN_EXPIRATION = 60 * 600; // 10시간 (초 단위)
+    private static final int REFRESH_TOKEN_EXPIRATION = 7 * 24 * 60 * 60; // 7일 (초 단위)
+
+    public void saveAccessTokenToCookie(HttpServletResponse response, String accessToken) {
+        Cookie accessTokenCookie = new Cookie(ACCESS_TOKEN_COOKIE_NAME, accessToken);
+        accessTokenCookie.setPath("/");
+        accessTokenCookie.setHttpOnly(true);
+        accessTokenCookie.setSecure(true);
+        accessTokenCookie.setDomain(DOMAIN);
+        accessTokenCookie.setMaxAge(ACCESS_TOKEN_EXPIRATION);
+        response.addCookie(accessTokenCookie);
+    }
+
+    public void saveRefreshTokenToCookie(HttpServletResponse response, String refreshToken) {
+        Cookie refreshTokenCookie = new Cookie(REFRESH_TOKEN_COOKIE_NAME, refreshToken);
+        refreshTokenCookie.setPath("/");
+        refreshTokenCookie.setHttpOnly(true);
+        refreshTokenCookie.setSecure(true);
+        refreshTokenCookie.setDomain(DOMAIN);
+        refreshTokenCookie.setMaxAge(REFRESH_TOKEN_EXPIRATION);
+        response.addCookie(refreshTokenCookie);
+    }
+
+    public void clearAuthCookies(HttpServletResponse response) {
+        Cookie accessTokenCookie = new Cookie(ACCESS_TOKEN_COOKIE_NAME, "");
+        accessTokenCookie.setPath("/");
+        accessTokenCookie.setHttpOnly(true);
+        accessTokenCookie.setSecure(true);
+        accessTokenCookie.setDomain(DOMAIN);
+        accessTokenCookie.setMaxAge(0); // 즉시 만료
+        response.addCookie(accessTokenCookie);
+
+        Cookie refreshTokenCookie = new Cookie(REFRESH_TOKEN_COOKIE_NAME, "");
+        refreshTokenCookie.setPath("/");
+        refreshTokenCookie.setHttpOnly(true);
+        refreshTokenCookie.setSecure(true);
+        refreshTokenCookie.setDomain(DOMAIN);
+        refreshTokenCookie.setMaxAge(0); // 즉시 만료
+        response.addCookie(refreshTokenCookie);
+    }
+}

--- a/src/test/java/com/WearWeather/wear/domain/auth/facade/LoginFacadeTest.java
+++ b/src/test/java/com/WearWeather/wear/domain/auth/facade/LoginFacadeTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.when;
 
 import com.WearWeather.wear.domain.auth.dto.request.LoginRequest;
 import com.WearWeather.wear.domain.auth.dto.response.LoginResponse;
+import com.WearWeather.wear.domain.auth.dto.response.TokenResponse;
 import com.WearWeather.wear.domain.auth.provider.AuthenticationProvider;
 import com.WearWeather.wear.domain.user.entity.User;
 import com.WearWeather.wear.domain.user.service.UserService;
@@ -67,7 +68,7 @@ public class LoginFacadeTest {
         when(tokenProvider.createAccessToken(authentication)).thenReturn("accessToken");
 
         // when
-        LoginResponse result = loginFacade.checkLogin(request);
+        TokenResponse result = loginFacade.checkLogin(request);
 
         // then
         assertNotNull(result);
@@ -90,7 +91,7 @@ public class LoginFacadeTest {
         when(tokenProvider.createAccessToken(authentication)).thenReturn("accessToken");
 
         // when
-        LoginResponse response = loginFacade.checkLogin(request);
+        TokenResponse response = loginFacade.checkLogin(request);
 
         // then
         assertNotNull(response);

--- a/src/test/java/com/WearWeather/wear/domain/auth/facade/ReissueFacadeTest.java
+++ b/src/test/java/com/WearWeather/wear/domain/auth/facade/ReissueFacadeTest.java
@@ -96,11 +96,10 @@ public class ReissueFacadeTest {
         when(tokenProvider.createAccessToken(authentication)).thenReturn(newAccessToken);
 
         // when
-        TokenResponse response = reissueFacade.reissue(refreshToken);
+        String accessToken = reissueFacade.reissue(refreshToken);
 
         // then
-        assertNotNull(response);
-        assertEquals(newAccessToken, response.getAccessToken());
+        assertNotNull(accessToken);
 
     }
 }


### PR DESCRIPTION
### 작업 개요
- 프론트 쪽에서 서버 사이드 렌더링을 구현하기 위해 nextjs로 마이그레이션하고 있는 것에 대해서 기존 로그인 후 토큰 전달 방식에 대한 수정을 요구함

### 📝 변경 내용
- 기존에는 Access Token(AT)이 클라이언트 환경(메모리)에 저장되어 있어, 서버 사이드 렌더링(SSR) 시 토큰을 가져올 수 없는 문제가 발생함.
- 이를 해결하기 위해 Access Token을 쿠키에 저장하도록 변경.
- Next.js 서버에서 요청 시 쿠키를 통해 토큰을 가져올 수 있으므로, 서버 사이드 렌더링이 가능해짐.

### 🔧 주요 변경 사항
- 로그인 시 Access Token을 `HttpOnly` 및 `SameSite=Strict` 쿠키로 설정하여 보안 강화.
- 클라이언트 환경(localStorage)이 아닌, 서버에서도 접근 가능한 방식으로 인증 처리.