### PR TITLE
오늘의 온도에 맞는 게시글 조회 수정

### DIFF
--- a/src/main/java/com/WearWeather/wear/domain/post/repository/PostByTemperatureRepositoryCustomImpl.java
+++ b/src/main/java/com/WearWeather/wear/domain/post/repository/PostByTemperatureRepositoryCustomImpl.java
@@ -34,7 +34,6 @@ public class PostByTemperatureRepositoryCustomImpl implements PostByTemperatureR
                         qPost.temperature.between(rangeStart, rangeEnd),
                         qPost.id.notIn(invisiblePostIds)
                 )
-                .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .orderBy(qPost.createdAt.desc())
                 .fetch();


### PR DESCRIPTION
## 개요
현재 기온에 어울리는 룩은 최신 10개 게시글만 조회하도록 범위가 고정되어있어, offset 조건이 불필요하므로 삭제 처리