### PR TITLE
Git Flow 도입에 따라 스프링 프로필(dev/prod/local) 분리

### DIFF
--- a/.github/workflows/cd-deploy.yml
+++ b/.github/workflows/cd-deploy.yml
@@ -55,5 +55,5 @@ jobs:
             mv /home/ubuntu/WearWeather-BackEnd/tobe/project.jar /home/ubuntu/WearWeather-BackEnd/current/project.jar
             cd /home/ubuntu/WearWeather-BackEnd/current
             sudo fuser -k -n tcp 8080 || true
-            JASYPT_ENCRYPTOR_PASSWORD=${{ secrets.JASYPT_ENCRYPTOR_PASSWORD }} nohup java -jar project.jar > ./output.log 2>&1 &
+            JASYPT_ENCRYPTOR_PASSWORD=${{ secrets.JASYPT_ENCRYPTOR_PASSWORD }} nohup java -jar project.jar --spring.profiles.active=prod > ./output.log 2>&1 &
             rm -rf /home/ubuntu/WearWeather-BackEnd/tobe

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: 테스트 진행하기
         env:
-          SPRING_PROFILES_ACTIVE: test
+          SPRING_PROFILES_ACTIVE: dev
           JASYPT_ENCRYPTOR_PASSWORD: ${{ secrets.JASYPT_ENCRYPTOR_PASSWORD }}
         run: ./gradlew --info test
 

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,0 +1,9 @@
+spring:
+  datasource:
+    url: ENC(57mqe+sicTFjtM7QsRuV7+GIhWUhBvY9VE4HYlZ4xIAEm3fyht51MMc+SgrasGbE)
+    username: ENC(MrFfIG3pbqaaHYcUDXWAo4zAqGxBkxhJ)
+    password: ENC(wy50yLHyaXLntHWcCeacL+eg4Ibw1o3J)
+  jpa:
+    hibernate:
+      ddl-auto: update
+    database-platform: org.hibernate.dialect.MySQLDialect

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,8 +1,8 @@
 spring:
   datasource:
-    url: jdbc:mysql://localhost:3306/test_db
-    username: test_user
-    password: test_password
+    url: jdbc:mysql://localhost:3306/wearweather
+    username: root
+    password: 1234
   jpa:
     hibernate:
       ddl-auto: update

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,7 +4,14 @@ spring:
   config:
     import: classpath:common.yml
   profiles:
-    active: prod
+    default: "local"
+    group:
+      local:
+        - common
+      dev:
+        - common
+      prod:
+        - common
 
 server:
   servlet:


### PR DESCRIPTION
## 🚩 연관 이슈
close #126

## 🗣️ 작업 개요
초기 빠른 구현을 위해 기존에는 GitHub Flow 전략에 따라 prod, test 프로필만 운영되었으나,
운영 서버에서 예상치 못한 이슈에 대한 대응이 지연되면서 전체 작업 일정이 밀리고, 운영에도 점차 영향을 주게 되었다.
이에 따라 사전 검증이 가능한 dev 환경 추가하고, Git Flow 전략에 맞춰 prod, dev, local 프로필로 설정을 분리하는 작업을 진행

## 📝 작업 내용
- 로컬에서 서버 실행 시 기본적으로 `local` 프로필이 적용되도록 설정
- CI 환경에서는 `dev`, CD 환경에서는 `prod` 프로필이 적용되도록 설정
