### PR TITLE
Spring REST Docs 적용

### DIFF
--- a/.github/workflows/cd-deploy.yml
+++ b/.github/workflows/cd-deploy.yml
@@ -8,6 +8,25 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+
+    services:
+      redis:
+        image: redis:latest
+        ports:
+          - 6379:6379
+        options: --health-cmd "redis-cli ping" --health-interval=10s --health-timeout=5s --health-retries=3
+
+      mysql:
+        image: mysql:latest
+        env:
+          MYSQL_ROOT_PASSWORD: test_password
+          MYSQL_DATABASE: test_db
+          MYSQL_USER: test_user
+          MYSQL_PASSWORD: test_password
+        ports:
+          - 3306:3306
+        options: --health-cmd "mysqladmin ping --silent" --health-interval=10s --health-timeout=5s --health-retries=3
+
     steps:
       - name: Github Repository 가져오기
         uses: actions/checkout@v4
@@ -28,7 +47,7 @@ jobs:
           java-version: 17
 
       - name: 빌드하기
-        run: ./gradlew clean build -x test
+        run: ./gradlew clean build
 
       - name: 빌드된 파일 이름 변경하기
         run: mv ./build/libs/*SNAPSHOT.jar ./project.jar

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.3.1'
     id 'io.spring.dependency-management' version '1.1.5'
+    id 'org.asciidoctor.jvm.convert' version '3.3.2'
 }
 
 group = 'com.WearWeather'
@@ -17,6 +18,11 @@ configurations {
     compileOnly {
         extendsFrom annotationProcessor
     }
+    asciidoctorExt
+}
+
+ext {
+    snippetsDir = file('build/generated-snippets')
 }
 
 repositories {
@@ -24,6 +30,8 @@ repositories {
 }
 
 dependencies {
+    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+    asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
 
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
@@ -86,4 +94,25 @@ tasks.withType(JavaCompile) {
 
 tasks.named('test') {
     useJUnitPlatform()
+    outputs.dir snippetsDir
+}
+
+asciidoctor {
+    configurations 'asciidoctorExt'
+    inputs.dir snippetsDir
+    dependsOn test
+}
+
+asciidoctor.doFirst {
+    delete file('src/main/resources/static/docs')
+}
+
+tasks.register('copyDocument', Copy) {
+    dependsOn asciidoctor
+    from file("build/docs/asciidoc")
+    into file("src/main/resources/static/docs")
+}
+
+build {
+    dependsOn copyDocument
 }

--- a/src/docs/asciidoc/Auth_API.adoc
+++ b/src/docs/asciidoc/Auth_API.adoc
@@ -1,0 +1,29 @@
+= 인증 API 문서
+:toc: left
+:toclevels: 2
+:source-highlighter: highlightjs
+:snippets: build/generated-snippets
+
+[#login-api]
+== 로그인 API
+- 사용자가 이메일과 비밀번호를 입력하여 로그인합니다.
+- 요청 DTO: `LoginRequest`
+- 응답 DTO: 없음 (쿠키에 토큰 전달)
+
+operation::auth-controller-test/login[snippets='http-request,request-fields,http-response']
+
+[#logout-api]
+== 로그아웃 API
+- 사용자가 로그아웃하면 서버에서 토큰을 무효화하고 쿠키를 제거합니다.
+- 요청 DTO: 없음
+- 응답 DTO: `ResponseCommonDTO`
+
+operation::auth-controller-test/logout[snippets='http-request,request-headers,http-response,response-fields']
+
+[#reissue-api]
+== 토큰 재발급 API
+- 만료된 Access Token이 감지되면, Refresh Token을 기반으로 새로운 Access Token을 발급합니다.
+- 요청 DTO: 없음 (RefreshToken은 쿠키에서 전달)
+- 응답 DTO: 없음 (쿠키에 새로운 Access Token 전달)
+
+operation::auth-controller-test/reissue[snippets='http-request,request-cookies,http-response']

--- a/src/docs/asciidoc/Email_API.adoc
+++ b/src/docs/asciidoc/Email_API.adoc
@@ -1,0 +1,21 @@
+= 이메일 인증 API 문서
+:toc: left
+:toclevels: 2
+:source-highlighter: highlightjs
+:snippets: build/generated-snippets
+
+[#send-verification]
+== 이메일 인증 요청 API
+- 사용자가 이메일을 입력하면 해당 주소로 인증 코드를 전송합니다.
+- 요청 DTO: `VerifyEmailRequest`
+- 응답 DTO: `ResponseCommonDTO`
+
+operation::email-controller-test/send_verification[snippets='http-request,request-fields,http-response,response-fields']
+
+[#verify-code]
+== 이메일 인증 코드 검증 API
+- 이메일로 전송된 인증 코드를 사용자가 입력하여 검증합니다.
+- 요청 DTO: `VerifyEmailAuthCodeRequest`
+- 응답 DTO: `ResponseCommonDTO`
+
+operation::email-controller-test/verify_code[snippets='http-request,request-fields,http-response,response-fields']

--- a/src/docs/asciidoc/Location_API.adoc
+++ b/src/docs/asciidoc/Location_API.adoc
@@ -1,0 +1,37 @@
+= 위치 API 문서
+:toc: left
+:toclevels: 2
+:source-highlighter: highlightjs
+:snippets: build/generated-snippets
+
+[#get-location-data]
+== 기본 위치 데이터 저장 API
+- 관리자용으로 기본 시/군/구 위치 데이터를 내부에 저장하는 API입니다.
+- 요청 DTO: 없음
+- 응답 DTO: 없음
+
+operation::location-controller-test/get-location-data[snippets='http-request']
+
+[#geocoding-location]
+== 좌표 기반 위치 조회 API
+- 경도와 위도를 기반으로 시/군/구 정보를 조회하는 API입니다.
+- 요청 DTO: 없음 (쿼리 파라미터 사용)
+- 응답 DTO: `GeocodingLocationResponse`
+
+operation::location-controller-test/geocoding-location[snippets='http-request,query-parameters,http-response,response-fields']
+
+[#search-location]
+== 주소 기반 위치 검색 API
+- 사용자가 주소를 입력하면 도시, 구, 좌표 등의 정보를 응답합니다.
+- 요청 DTO: 없음 (쿼리 파라미터 사용)
+- 응답 DTO: `SearchLocationResponse`
+
+operation::location-controller-test/search-location[snippets='http-request,query-parameters,http-response,response-fields']
+
+[#get-regions]
+== 전체 시/군/구 데이터 조회 API
+- 프로젝트에 저장된 모든 시와 군/구 정보를 조회하는 API입니다.
+- 요청 DTO: 없음
+- 응답 DTO: `RegionsResponse`
+
+operation::location-controller-test/get-regions[snippets='http-request,http-response,response-fields']

--- a/src/docs/asciidoc/OAuth_API.adoc
+++ b/src/docs/asciidoc/OAuth_API.adoc
@@ -1,0 +1,13 @@
+= 소셜 로그인 API 문서
+:toc: left
+:toclevels: 2
+:source-highlighter: highlightjs
+:snippets: build/generated-snippets
+
+[#kakao-login]
+== 카카오 소셜 로그인 API
+- 카카오 OAuth 인증 코드를 받아 로그인 처리하고, access/refresh 토큰을 쿠키로 발급합니다.
+- 요청 DTO: 없음 (Query Parameter)
+- 응답 DTO: `없음`
+
+operation::o-auth-controller-test/kakao-login[snippets='http-request,query-parameters,http-response']

--- a/src/docs/asciidoc/PostHidden_API.adoc
+++ b/src/docs/asciidoc/PostHidden_API.adoc
@@ -1,0 +1,13 @@
+= 게시글 숨김 처리 API 문서
+:toc: left
+:toclevels: 2
+:source-highlighter: highlightjs
+:snippets: build/generated-snippets
+
+[#hide-post]
+== 게시글 숨김 처리 API
+- 사용자가 특정 게시글을 숨깁니다. 숨긴 게시글은 더 이상 메인 피드에 노출되지 않습니다.
+- 요청 DTO: 없음 (PathVariable로 postId만 전달)
+- 응답 DTO: `ResponseCommonDTO`
+
+operation::post-hidden-controller-test/hide-post[snippets='path-parameters,http-request,http-response,response-fields']

--- a/src/docs/asciidoc/PostImage_API.adoc
+++ b/src/docs/asciidoc/PostImage_API.adoc
@@ -1,0 +1,21 @@
+= S3 이미지 업로드 및 삭제 API 문서
+:toc: left
+:toclevels: 2
+:source-highlighter: highlightjs
+:snippets: build/generated-snippets
+
+[#upload-post-image]
+== 게시글 이미지 업로드 API
+- 사용자가 게시글 작성을 위해 이미지를 업로드하면, S3에 저장된 이미지의 URL과 ID를 반환합니다.
+- 요청 DTO: `MultipartFile` (RequestPart)
+- 응답 DTO: `ImageInfoResponse`
+
+operation::aws-s3-controller-test/upload-post-image[snippets='request-parts,http-request,http-response,response-fields']
+
+[#delete-post-image]
+== 게시글 이미지 삭제 API
+- 게시글 이미지 ID를 이용해 해당 이미지를 S3에서 삭제합니다.
+- 요청 DTO: 없음 (PathVariable로 전달)
+- 응답 DTO: 없음 (`204 No Content`)
+
+operation::aws-s3-controller-test/delete-post-image[snippets='path-parameters,http-request,http-response']

--- a/src/docs/asciidoc/PostLike_API.adoc
+++ b/src/docs/asciidoc/PostLike_API.adoc
@@ -1,0 +1,29 @@
+= 게시글 좋아요 API 문서
+:toc: left
+:toclevels: 2
+:source-highlighter: highlightjs
+:snippets: build/generated-snippets
+
+[#add-like]
+== 게시글 좋아요 추가 API
+- 사용자가 특정 게시글에 좋아요를 추가합니다.
+- 요청 DTO: 없음 (PathVariable로 postId 전달)
+- 응답 DTO: `TotalLikedCountAfterLike`
+
+operation::like-controller-test/add-like[snippets='path-parameters,http-request,http-response,response-fields']
+
+[#remove-like]
+== 게시글 좋아요 취소 API
+- 사용자가 특정 게시글에 추가한 좋아요를 취소합니다.
+- 요청 DTO: 없음 (PathVariable로 postId 전달)
+- 응답 DTO: `TotalLikedCountAfterUnlike`
+
+operation::like-controller-test/remove-like[snippets='path-parameters,http-request,http-response,response-fields']
+
+[#get-liked-posts-by-me]
+== 내가 좋아요한 게시글 목록 조회 API
+- 사용자가 좋아요한 게시글 목록을 페이지네이션으로 조회합니다.
+- 요청 DTO: 없음 (Query Parameters)
+- 응답 DTO: `LikedPostsByMeResponse`
+
+operation::like-controller-test/get-liked-posts-by-me[snippets='query-parameters,http-request,http-response,response-fields']

--- a/src/docs/asciidoc/PostReport_API.adoc
+++ b/src/docs/asciidoc/PostReport_API.adoc
@@ -1,0 +1,13 @@
+= 게시글 신고 API 문서
+:toc: left
+:toclevels: 2
+:source-highlighter: highlightjs
+:snippets: build/generated-snippets
+
+[#report-post]
+== 게시글 신고 API
+- 사용자가 특정 게시글을 사유(reason)와 함께 신고합니다.
+- 요청 DTO: 없음 (PathVariable + @RequestParam으로 처리)
+- 응답 DTO: `ResponseCommonDTO`
+
+operation::post-report-controller-test/report-post[snippets='path-parameters,query-parameters,http-request,http-response,response-fields']

--- a/src/docs/asciidoc/Post_API.adoc
+++ b/src/docs/asciidoc/Post_API.adoc
@@ -1,0 +1,77 @@
+= 게시글 API 문서
+:toc: left
+:toclevels: 2
+:source-highlighter: highlightjs
+:snippets: build/generated-snippets
+
+[#create-post]
+== 게시글 생성 API
+- 사용자가 게시글을 작성합니다.
+- 요청 DTO: `PostCreateRequest`
+- 응답 DTO: `PostCreateResponse`
+
+operation::post-controller-test/create[snippets='http-request,request-fields,http-response,response-fields']
+
+[#update-post]
+== 게시글 수정 API
+- 게시글 ID를 기준으로 게시글 내용을 수정합니다.
+- 요청 DTO: `PostUpdateRequest`
+- 응답 DTO: `ResponseCommonDTO`
+
+operation::post-controller-test/update[snippets='http-request,path-parameters,request-fields,http-response,response-fields']
+
+[#delete-post]
+== 게시글 삭제 API
+- 게시글 ID를 기준으로 게시글을 삭제합니다.
+- 요청 DTO: 없음
+- 응답 DTO: `ResponseCommonDTO`
+
+operation::post-controller-test/delete[snippets='http-request,path-parameters,http-response,response-fields']
+
+[#get-top-liked-posts]
+== 좋아요 많은 게시글 조회 API
+- 좋아요 수 기준으로 인기 게시글을 조회합니다.
+- 요청 DTO: 없음
+- 응답 DTO: `TopLikedPostsResponse`
+
+operation::post-controller-test/get-top-liked-posts[snippets='http-request,http-response,response-fields']
+
+[#get-post-detail]
+== 게시글 상세 조회 API
+- 게시글 ID를 기준으로 상세 정보를 조회합니다.
+- 요청 DTO: 없음
+- 응답 DTO: `PostDetailResponse`
+
+operation::post-controller-test/get-post-detail[snippets='http-request,path-parameters,http-response,response-fields']
+
+[#get-posts-by-location]
+== 위치 기반 게시글 조회 API
+- 시/군/구 위치를 기반으로 게시글을 조회합니다.
+- 요청 DTO: 없음 (Query Parameter 기반)
+- 응답 DTO: `PostsByLocationResponse`
+
+operation::post-controller-test/get-posts-by-location[snippets='http-request,query-parameters,http-response,response-fields']
+
+[#search-posts-by-filters]
+== 조건 기반 게시글 검색 API
+- 필터 조건(지역, 날씨, 온도, 계절 등)에 따라 게시글을 검색합니다.
+- 요청 DTO: `PostsByFiltersRequest`
+- 응답 DTO: `PostsByFiltersResponse`
+
+operation::post-controller-test/search-posts-by-filters[snippets='http-request,request-fields,http-response,response-fields']
+
+[#get-posts-by-temperature]
+== 온도 기반 게시글 조회 API
+- 특정 온도 조건에 맞는 게시글을 조회합니다.
+- 요청 DTO: 없음 (Query Parameter 기반)
+- 응답 DTO: `PostsByTemperatureResponse`
+
+operation::post-controller-test/get-posts-by-temperature[snippets='http-request,query-parameters,http-response,response-fields']
+
+[#get-posts-by-me]
+== 내가 작성한 게시글 조회 API
+- 로그인한 사용자가 작성한 게시글 목록을 조회합니다.
+- 요청 DTO: 없음 (Query Parameter 기반)
+- 응답 DTO: `PostsByMeResponse`
+
+operation::post-controller-test/get-posts-by-me[snippets='http-request,query-parameters,http-response,response-fields']

--- a/src/docs/asciidoc/UserDelete_API.adoc
+++ b/src/docs/asciidoc/UserDelete_API.adoc
@@ -1,0 +1,13 @@
+= 회원 탈퇴 관련 API 문서
+:toc: left
+:toclevels: 2
+:source-highlighter: highlightjs
+:snippets: build/generated-snippets
+
+[#get-delete-reasons]
+== 회원 탈퇴 사유 조회 API
+- 사용자가 회원 탈퇴 시 선택할 수 있는 사유 목록을 조회합니다.
+- 요청 DTO: 없음
+- 응답 DTO: `List<String>`
+
+operation::user-delete-controller-test/get_delete_reasons[snippets='http-request,http-response,response-fields']

--- a/src/docs/asciidoc/User_API.adoc
+++ b/src/docs/asciidoc/User_API.adoc
@@ -1,0 +1,69 @@
+= 사용자 관련 API 문서
+:toc: left
+:toclevels: 2
+:source-highlighter: highlightjs
+:snippets: build/generated-snippets
+
+[#signup-api]
+== 회원가입 API
+- 이메일, 비밀번호, 이름, 닉네임을 입력받아 회원가입을 진행합니다.
+- 요청 DTO: `RegisterUserRequest`
+- 응답 DTO: `ResponseCommonDTO`
+
+operation::user-controller-test/signup[snippets='http-request,request-fields,http-response,response-fields']
+
+[#check-duplicate-nickname]
+== 닉네임 중복 확인 API
+- 입력한 닉네임이 중복되는지 확인합니다.
+- 요청 DTO: 없음 (`PathVariable`)
+- 응답 DTO: `NicknameDuplicateCheckResponse`
+
+operation::user-controller-test/check-duplicate-nickname[snippets='path-parameters,http-request,http-response,response-fields']
+
+[#find-user-email]
+== 이메일 찾기 API
+- 이름과 닉네임을 기반으로 등록된 이메일을 조회합니다.
+- 요청 DTO: `FindUserEmailRequest`
+- 응답 DTO: `FindUserEmailResponse`
+
+operation::user-controller-test/find-user-email[snippets='http-request,request-fields,http-response,response-fields']
+
+[#find-user-password]
+== 비밀번호 찾기 API
+- 이메일, 이름, 닉네임을 기반으로 비밀번호 변경을 위한 사용자 ID를 조회합니다.
+- 요청 DTO: `FindUserPasswordRequest`
+- 응답 DTO: `UserIdForPasswordUpdateResponse`
+
+operation::user-controller-test/find-user-password[snippets='http-request,request-fields,http-response,response-fields']
+
+[#modify-user-password]
+== 비밀번호 변경 API
+- 사용자 ID와 새로운 비밀번호를 입력받아 비밀번호를 변경합니다.
+- 요청 DTO: `ModifyUserPasswordRequest`
+- 응답 DTO: `ResponseCommonDTO`
+
+operation::user-controller-test/modify_user_password[snippets='http-request,request-fields,http-response,response-fields']
+
+[#get-user-info]
+== 내 정보 조회 API
+- 현재 로그인한 사용자의 프로필 정보를 조회합니다.
+- 요청 DTO: 없음
+- 응답 DTO: `UserInfoResponse`
+
+operation::user-controller-test/get_user_info[snippets='http-request,http-response,response-fields']
+
+[#modify-user-info]
+== 내 정보 수정 API
+- 비밀번호와 닉네임을 수정합니다.
+- 요청 DTO: `ModifyUserInfoRequest`
+- 응답 DTO: `ResponseCommonDTO`
+
+operation::user-controller-test/modify_user_info[snippets='http-request,request-fields,http-response,response-fields']
+
+[#delete-user]
+== 회원 탈퇴 API
+- 사용자의 탈퇴 사유를 입력받아 계정을 삭제합니다.
+- 요청 DTO: 없음 (`@RequestParam`)
+- 응답 DTO: `ResponseCommonDTO`
+
+operation::user-controller-test/delete_user[snippets='query-parameters,http-request,http-response,response-fields']

--- a/src/docs/asciidoc/Weather_API.adoc
+++ b/src/docs/asciidoc/Weather_API.adoc
@@ -1,0 +1,29 @@
+= 날씨 관련 API 문서
+:toc: left
+:toclevels: 2
+:source-highlighter: highlightjs
+:snippets: build/generated-snippets
+
+[#get-weather-per-time]
+== 시간대별 날씨 조회 API
+- 위도와 경도를 기반으로 현재 날씨(기온, 설명 등)를 조회합니다.
+- 요청 DTO: 없음 (쿼리 파라미터 사용)
+- 응답 DTO: `WeatherPerTimeResponse`
+
+operation::weather-controller-test/get_weather_per_time[snippets='query-parameters,http-request,http-response,response-fields']
+
+[#get-weather-tmp]
+== 최저/최고 기온 조회 API
+- 위도와 경도를 기반으로 해당 지역의 최저/최고 기온을 조회합니다.
+- 요청 DTO: 없음 (쿼리 파라미터 사용)
+- 응답 DTO: `WeatherTmpResponse`
+
+operation::weather-controller-test/get_weather_tmp[snippets='query-parameters,http-request,http-response,response-fields']
+
+[#get-outfit-guide]
+== 옷차림 가이드 API
+- 기온(℃)에 따라 추천 옷차림을 제공합니다.
+- 요청 DTO: 없음 (쿼리 파라미터 사용)
+- 응답 DTO: `OutfitGuideResponse`
+
+operation::weather-controller-test/get_outfit_guide[snippets='query-parameters,http-request,http-response,response-fields']

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1,0 +1,94 @@
+
+= LookattheWeather API Documentation
+lookattheweather.github.io(부제)
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 2
+:sectlinks:
+
+== Introduction
+
+**LookattheWeather**는 날씨 기반 의류 추천 및 게시글 공유 서비스를 제공하는 API입니다.
+
+본 문서는 해당 서비스의 주요 API 엔드포인트를 설명하고, 각 요청 및 응답 형식에 대한 정보를 포함합니다.
+
+* 작성자: 이건희 (Backend Developer)
+* 문서 목적: 내부 개발자 및 협업자를 위한 REST API 명세서
+* 문서 구조: 도메인별로 분리된 문서 링크를 포함하며, 각 문서에 개별 API 테스트 결과를 자동 포함합니다.
+
+== API Endpoints
+
+=== link:Auth_API.html[Auth API, window=_blank]
+* link:Auth_API.html#login-api[로그인 API, window=_blank]
+* link:Auth_API.html#logout-api[로그아웃 API, window=_blank]
+* link:Auth_API.html#reissue-api[토큰 재발급 API, window=_blank]
+
+
+=== link:Location_API.html[Location API, window=_blank]
+* link:Location_API.html#get-location-data[기본 위치 데이터 저장 API, window=_blank]
+* link:Location_API.html#geocoding-location[좌표 기반 위치 조회 API, window=_blank]
+* link:Location_API.html#search-location[주소 기반 위치 검색 API, window=_blank]
+* link:Location_API.html#get-regions[전체 시/군/구 데이터 조회 API, window=_blank]
+
+
+=== link:Email_API.html[Email API, window=_blank]
+* link:Email_API.html#send-verification[이메일 인증 요청 API, window=_blank]
+* link:Email_API.html#verify-code[이메일 인증 코드 검증 API, window=_blank]
+
+
+=== link:OAuth_API.html[OAuth API, window=_blank]
+* link:OAuth_API.html#kakao-login[카카오 소셜 로그인 API, window=_blank]
+
+
+=== link:Post_API.html[Post API, window=_blank]
+* link:Post_API.html#create-post[게시글 생성 API, window=_blank]
+* link:Post_API.html#update-post[게시글 수정 API, window=_blank]
+* link:Post_API.html#delete-post[게시글 삭제 API, window=_blank]
+* link:Post_API.html#get-top-liked-posts[좋아요 많은 게시글 조회 API, window=_blank]
+* link:Post_API.html#get-post-detail[게시글 상세 조회 API, window=_blank]
+* link:Post_API.html#get-posts-by-location[위치 기반 게시글 조회 API, window=_blank]
+* link:Post_API.html#search-posts-by-filters[조건 기반 게시글 검색 API, window=_blank]
+* link:Post_API.html#get-posts-by-temperature[온도 기반 게시글 조회 API, window=_blank]
+* link:Post_API.html#get-posts-by-me[내가 작성한 게시글 조회 API, window=_blank]
+
+
+=== link:PostHidden_API.html[Post Hidden API, window=_blank]
+* link:PostHidden_API.html#hide-post[게시글 숨김 처리 API, window=_blank]
+
+
+=== link:PostLike_API.html[Post Like API, window=_blank]
+* link:PostLike_API.html#add-like[게시글 좋아요 추가 API, window=_blank]
+* link:PostLike_API.html#remove-like[게시글 좋아요 취소 API, window=_blank]
+* link:PostLike_API.html#get-liked-posts-by-me[내가 좋아요한 게시글 목록 조회 API, window=_blank]
+
+
+=== link:PostReport_API.html[Post Report API, window=_blank]
+* link:PostReport_API.html#report-post[게시글 신고 API, window=_blank]
+
+
+=== link:PostImage_API.html[Post Image API, window=_blank]
+* link:PostImage_API.html#upload-post-image[게시글 이미지 업로드 API, window=_blank]
+* link:PostImage_API.html#delete-post-image[게시글 이미지 삭제 API, window=_blank]
+
+
+=== link:User_API.html[User API, window=_blank]
+* link:User_API.html#signup-api[회원가입 API, window=_blank]
+* link:User_API.html#check-duplicate-nickname[닉네임 중복 확인 API, window=_blank]
+* link:User_API.html#find-user-email[이메일 찾기 API, window=_blank]
+* link:User_API.html#find-user-password[비밀번호 찾기 API, window=_blank]
+* link:User_API.html#modify-user-password[비밀번호 변경 API, window=_blank]
+* link:User_API.html#get-user-info[내 정보 조회 API, window=_blank]
+* link:User_API.html#modify-user-info[내 정보 수정 API, window=_blank]
+* link:User_API.html#delete-user[회원 탈퇴 API, window=_blank]
+
+
+=== link:UserDelete_API.html[User Delete API, window=_blank]
+* link:UserDelete_API.html#get-delete-reasons[회원 탈퇴 사유 조회 API, window=_blank]
+
+
+=== link:Weather_API.html[Weather API, window=_blank]
+* link:Weather_API.html#get-weather-per-time[시간대별 날씨 조회 API, window=_blank]
+* link:Weather_API.html#get-weather-tmp[최저/최고 기온 조회 API, window=_blank]
+* link:Weather_API.html#get-outfit-guide[옷차림 가이드 API, window=_blank]

--- a/src/main/java/com/WearWeather/wear/domain/location/controller/LocationController.java
+++ b/src/main/java/com/WearWeather/wear/domain/location/controller/LocationController.java
@@ -7,6 +7,7 @@ import com.WearWeather.wear.domain.location.service.LocationService;
 import java.util.Collections;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import reactor.core.publisher.Mono;
 
@@ -23,9 +24,10 @@ public class LocationController {
     }
 
     @GetMapping("/location")
-    public Mono<GeocodingLocationResponse> geocodingLocation(@RequestParam("longitude") double longitude,
-                                                             @RequestParam("latitude") double latitude){
-        return locationService.findLocationByGeoCoordApi(longitude, latitude);
+    public ResponseEntity<GeocodingLocationResponse> geocodingLocation(@RequestParam("longitude") double longitude,
+      @RequestParam("latitude") double latitude) {
+        GeocodingLocationResponse response = locationService.findLocationByGeoCoordApi(longitude, latitude).block();
+        return ResponseEntity.ok(response);
     }
 
     @GetMapping("/location/search")

--- a/src/main/java/com/WearWeather/wear/domain/post/dto/request/PostCreateRequest.java
+++ b/src/main/java/com/WearWeather/wear/domain/post/dto/request/PostCreateRequest.java
@@ -55,7 +55,7 @@ public class PostCreateRequest implements PostImageRequest, TaggableRequest {
 
     @NotNull(message = "이미지 리스트는 null일 수 없습니다.")
     @NotEmpty(message = "이미지 업로드는 필수입니다.")
-    private final List<@NotNull(message = "이미지 ID는 null일 수 없습니다.")
+    private  List<@NotNull(message = "이미지 ID는 null일 수 없습니다.")
                        @Positive(message = "이미지 ID는 양수여야 합니다.") Long> imageIds = new ArrayList<>();
 
     @JsonCreator
@@ -68,7 +68,8 @@ public class PostCreateRequest implements PostImageRequest, TaggableRequest {
         @JsonProperty("district") String district,
         @JsonProperty("weatherTagIds") Set<Long> weatherTagIds,
         @JsonProperty("temperatureTagIds") Set<Long> temperatureTagIds,
-        @JsonProperty("seasonTagId") Long seasonTagId
+        @JsonProperty("seasonTagId") Long seasonTagId,
+        @JsonProperty("imageIds") List<Long> imageIds
     ) {
         this.title = title;
         this.content = content;
@@ -79,6 +80,7 @@ public class PostCreateRequest implements PostImageRequest, TaggableRequest {
         this.weatherTagIds = weatherTagIds;
         this.temperatureTagIds = temperatureTagIds;
         this.seasonTagId = seasonTagId;
+        this.imageIds = imageIds;
     }
 
     public Post toEntity(Long userId,Location location) {

--- a/src/main/java/com/WearWeather/wear/domain/post/dto/request/PostUpdateRequest.java
+++ b/src/main/java/com/WearWeather/wear/domain/post/dto/request/PostUpdateRequest.java
@@ -46,7 +46,7 @@ public class PostUpdateRequest implements PostImageRequest, TaggableRequest {
     private final Long seasonTagId;
 
     @NotEmpty(message = "이미지 업로드는 필수입니다.")
-    private final List<Long> imageIds = new ArrayList<>();
+    private List<Long> imageIds = new ArrayList<>();
 
     @JsonCreator
     public PostUpdateRequest(
@@ -57,7 +57,8 @@ public class PostUpdateRequest implements PostImageRequest, TaggableRequest {
         @JsonProperty("gender") Gender gender,
         @JsonProperty("weatherTagIds") Set<Long> weatherTagIds,
         @JsonProperty("temperatureTagIds") Set<Long> temperatureTagIds,
-        @JsonProperty("seasonTagId") Long seasonTagId
+        @JsonProperty("seasonTagId") Long seasonTagId,
+        @JsonProperty("imageIds") List<Long> imageIds
     ) {
         this.title = title;
         this.content = content;
@@ -67,5 +68,6 @@ public class PostUpdateRequest implements PostImageRequest, TaggableRequest {
         this.weatherTagIds = weatherTagIds;
         this.temperatureTagIds = temperatureTagIds;
         this.seasonTagId = seasonTagId;
+        this.imageIds = imageIds;
     }
 }

--- a/src/main/java/com/WearWeather/wear/global/config/SecurityConfig.java
+++ b/src/main/java/com/WearWeather/wear/global/config/SecurityConfig.java
@@ -75,6 +75,7 @@ public class SecurityConfig {
             .requestMatchers(HttpMethod.GET, "/posts/tmp").permitAll()
 
             .requestMatchers("/h2-console/**").permitAll()
+            .requestMatchers("/docs/**").permitAll()
             .anyRequest().authenticated()
           )
 

--- a/src/test/java/com/WearWeather/wear/document/utils/RestDocsConfig.java
+++ b/src/test/java/com/WearWeather/wear/document/utils/RestDocsConfig.java
@@ -1,0 +1,28 @@
+package com.WearWeather.wear.document.utils;
+
+import static org.springframework.restdocs.snippet.Attributes.Attribute;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.restdocs.operation.preprocess.Preprocessors;
+
+@TestConfiguration
+public class RestDocsConfig {
+
+    @Bean
+    public RestDocumentationResultHandler write(){
+        return MockMvcRestDocumentation.document(
+          "{class-name}/{method-name}",
+          Preprocessors.preprocessRequest(Preprocessors.prettyPrint()),
+          Preprocessors.preprocessResponse(Preprocessors.prettyPrint())
+        );
+    }
+
+    public static Attribute field(
+      final String key,
+      final String value){
+        return new Attribute(key,value);
+    }
+}

--- a/src/test/java/com/WearWeather/wear/document/utils/RestDocsTestSupport.java
+++ b/src/test/java/com/WearWeather/wear/document/utils/RestDocsTestSupport.java
@@ -1,0 +1,47 @@
+package com.WearWeather.wear.document.utils;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.filter.CharacterEncodingFilter;
+
+@Disabled
+@Import(RestDocsConfig.class)
+@ExtendWith(RestDocumentationExtension.class)
+public abstract class RestDocsTestSupport {
+
+    @Autowired
+    protected RestDocumentationResultHandler restDocs;
+
+    @Autowired
+    protected ObjectMapper objectMapper;
+
+    protected MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp(WebApplicationContext context, RestDocumentationContextProvider provider) {
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(context)
+          .apply(MockMvcRestDocumentation.documentationConfiguration(provider))
+          .alwaysDo(print())
+          .alwaysDo(restDocs)
+          .addFilters(new CharacterEncodingFilter("UTF-8", true))
+          .build();
+    }
+
+    protected String createJson(Object dto) throws JsonProcessingException {
+        return objectMapper.writeValueAsString(dto);
+    }
+}

--- a/src/test/java/com/WearWeather/wear/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/WearWeather/wear/domain/auth/controller/AuthControllerTest.java
@@ -1,0 +1,135 @@
+package com.WearWeather.wear.domain.auth.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.cookies.CookieDocumentation.cookieWithName;
+import static org.springframework.restdocs.cookies.CookieDocumentation.requestCookies;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.WearWeather.wear.document.utils.RestDocsConfig;
+import com.WearWeather.wear.document.utils.RestDocsTestSupport;
+import com.WearWeather.wear.domain.auth.dto.request.LoginRequest;
+import com.WearWeather.wear.domain.auth.dto.response.TokenResponse;
+import com.WearWeather.wear.domain.auth.facade.LogOutFacade;
+import com.WearWeather.wear.domain.auth.facade.LoginFacade;
+import com.WearWeather.wear.domain.auth.facade.ReissueFacade;
+import com.WearWeather.wear.global.jwt.JwtCookieManager;
+import com.WearWeather.wear.global.jwt.UserIdArgumentResolver;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.MediaType;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+@WebMvcTest(AuthController.class)
+@Import(RestDocsConfig.class)
+@AutoConfigureMockMvc(addFilters = false)
+@MockBean(JpaMetamodelMappingContext.class)
+class AuthControllerTest extends RestDocsTestSupport {
+
+    @MockBean
+    private LoginFacade loginFacade;
+
+    @MockBean
+    private LogOutFacade logOutFacade;
+
+    @MockBean
+    private ReissueFacade reissueFacade;
+
+    @MockBean
+    private JwtCookieManager jwtCookieManager;
+
+    @MockBean
+    private UserIdArgumentResolver loggedInUserArgumentResolver;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        given(loggedInUserArgumentResolver.supportsParameter(any())).willReturn(true);
+        given(loggedInUserArgumentResolver.resolveArgument(any(), any(), any(), any())).willReturn(1L);
+    }
+
+    @Test
+    @DisplayName("로그인 API")
+    void login() throws Exception {
+        // given
+        LoginRequest request = new LoginRequest("test@email.com", "password123");
+        TokenResponse response = new TokenResponse("access-token", "refresh-token");
+
+        given(loginFacade.checkLogin(any(LoginRequest.class))).willReturn(response);
+
+        // when & then
+        mockMvc.perform(post("/auth/login")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(createJson(request)))
+          .andExpect(status().isOk())
+          .andDo(print())
+          .andDo(restDocs.document(
+            requestFields(
+              fieldWithPath("email").description("사용자 이메일"),
+              fieldWithPath("password").description("비밀번호")
+            )
+          ));
+    }
+
+    @Test
+    @DisplayName("로그아웃 API")
+    void logout() throws Exception {
+        // given
+        String tokenHeader = "Bearer dummy-token";
+
+        // when & then
+        mockMvc.perform(post("/auth/logout")
+            .header("Authorization", tokenHeader))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.success").value(true))
+          .andExpect(jsonPath("$.message").value("success logout"))
+          .andDo(print())
+          .andDo(restDocs.document(
+            requestHeaders(
+              headerWithName("Authorization").description("Bearer 토큰")
+            ),
+            responseFields(
+              fieldWithPath("success").description("성공 여부"),
+              fieldWithPath("message").description("로그아웃 결과 메시지")
+            )
+          ));
+    }
+
+    @Test
+    @DisplayName("토큰 재발급 API")
+    void reissue() throws Exception {
+        // given
+        Cookie refreshTokenCookie = new Cookie("refreshToken", "dummy-refresh-token");
+
+        given(reissueFacade.reissue(anyString())).willReturn("new-access-token");
+
+        // when & then
+        mockMvc.perform(post("/auth/reissue")
+            .cookie(refreshTokenCookie))
+          .andExpect(status().isOk())
+          .andDo(print())
+          .andDo(restDocs.document(
+            requestCookies(
+              cookieWithName("refreshToken").description("리프레시 토큰 쿠키")
+            )
+          ));
+    }
+}

--- a/src/test/java/com/WearWeather/wear/domain/location/controller/LocationControllerTest.java
+++ b/src/test/java/com/WearWeather/wear/domain/location/controller/LocationControllerTest.java
@@ -1,0 +1,138 @@
+package com.WearWeather.wear.domain.location.controller;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.WearWeather.wear.document.utils.RestDocsTestSupport;
+import com.WearWeather.wear.domain.location.dto.response.DistrictResponse;
+import com.WearWeather.wear.domain.location.dto.response.GeocodingLocationResponse;
+import com.WearWeather.wear.domain.location.dto.response.RegionResponse;
+import com.WearWeather.wear.domain.location.dto.response.RegionsResponse;
+import com.WearWeather.wear.domain.location.dto.response.SearchLocationResponse;
+import com.WearWeather.wear.domain.location.service.LocationService;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import reactor.core.publisher.Mono;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+@WebMvcTest(LocationController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@MockBean(JpaMetamodelMappingContext.class)
+class LocationControllerTest extends RestDocsTestSupport {
+
+    @MockBean
+    private LocationService locationService;
+
+    @Test
+    @DisplayName("기본 위치 데이터 저장 API")
+    void getLocationData() throws Exception {
+        mockMvc.perform(get("/basic-location"))
+          .andExpect(status().isOk())
+          .andDo(print())
+          .andDo(restDocs.document());
+    }
+
+    @Test
+    @DisplayName("좌표 기반 위치 정보 조회 API")
+    void geocodingLocation() throws Exception {
+        GeocodingLocationResponse response = GeocodingLocationResponse.of("서울", 1L, "강남구", 2L);
+
+        given(locationService.findLocationByGeoCoordApi(127.0, 37.5))
+          .willReturn(Mono.just(response));
+
+        mockMvc.perform(get("/location")
+            .param("longitude", "127.0")
+            .param("latitude", "37.5"))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.city").value("서울"))
+          .andExpect(jsonPath("$.district").value("강남구"))
+          .andDo(print())
+          .andDo(restDocs.document(
+            queryParameters(
+              parameterWithName("longitude").description("경도"),
+              parameterWithName("latitude").description("위도")
+            ),
+            responseFields(
+              fieldWithPath("city").description("도시 이름"),
+              fieldWithPath("cityId").description("도시 ID"),
+              fieldWithPath("district").description("구 이름"),
+              fieldWithPath("districtId").description("구 ID")
+            )
+          ));
+    }
+
+    @Test
+    @DisplayName("주소 기반 위치 검색 API")
+    void searchLocation() throws Exception {
+        List<SearchLocationResponse> results = List.of(
+          SearchLocationResponse.of("서울 강남구", "127.0", "37.5", "서울", 1L, "강남구", 2L)
+        );
+
+        given(locationService.searchLocation("서울"))
+          .willReturn(results);
+
+        mockMvc.perform(get("/location/search")
+            .param("address", "서울"))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$[0].address_name").value("서울 강남구"))
+          .andDo(print())
+          .andDo(restDocs.document(
+            queryParameters(
+              parameterWithName("address").description("검색할 주소 문자열")
+            ),
+            responseFields(
+              fieldWithPath("[].address_name").description("전체 주소"),
+              fieldWithPath("[].longitude").description("경도"),
+              fieldWithPath("[].latitude").description("위도"),
+              fieldWithPath("[].cityName").description("도시 이름"),
+              fieldWithPath("[].cityId").description("도시 ID"),
+              fieldWithPath("[].districtName").description("구 이름"),
+              fieldWithPath("[].districtId").description("구 ID")
+            )
+          ));
+    }
+
+    @Test
+    @DisplayName("전체 행정구역 목록 조회 API")
+    void getRegions() throws Exception {
+        List<RegionResponse> regions = List.of(
+          RegionResponse.of(1L, "서울", List.of(
+            DistrictResponse.of(2L, "강남구"),
+            DistrictResponse.of(3L, "서초구")
+          ))
+        );
+        RegionsResponse response = RegionsResponse.of(regions);
+
+        given(locationService.getRegions()).willReturn(response);
+
+        mockMvc.perform(get("/regions"))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.region[0].cityId").value(1L))
+          .andExpect(jsonPath("$.region[0].cityName").value("서울"))
+          .andExpect(jsonPath("$.region[0].district[0].districtName").value("강남구"))
+          .andDo(print())
+          .andDo(restDocs.document(
+            responseFields(
+              fieldWithPath("region[].cityId").description("도시 ID"),
+              fieldWithPath("region[].cityName").description("도시 이름"),
+              fieldWithPath("region[].district[].districtId").description("구 ID"),
+              fieldWithPath("region[].district[].districtName").description("구 이름")
+            )
+          ));
+    }
+}

--- a/src/test/java/com/WearWeather/wear/domain/mail/controller/EmailControllerTest.java
+++ b/src/test/java/com/WearWeather/wear/domain/mail/controller/EmailControllerTest.java
@@ -1,0 +1,87 @@
+package com.WearWeather.wear.domain.mail.controller;
+
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.WearWeather.wear.document.utils.RestDocsTestSupport;
+import com.WearWeather.wear.domain.mail.dto.request.VerifyEmailAuthCodeRequest;
+import com.WearWeather.wear.domain.mail.dto.request.VerifyEmailRequest;
+import com.WearWeather.wear.domain.mail.service.MailService;
+import com.WearWeather.wear.global.common.ResponseMessage;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.MediaType;
+
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+@MockBean(JpaMetamodelMappingContext.class)
+@WebMvcTest(EmailController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class EmailControllerTest extends RestDocsTestSupport {
+
+    @MockBean
+    private MailService mailService;
+
+    @Test
+    @DisplayName("이메일 인증 메일 발송 API")
+    void send_verification() throws Exception {
+        // given
+        VerifyEmailRequest request = new VerifyEmailRequest("test@example.com");
+
+        // when & then
+        mockMvc.perform(post("/email/send-verification")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(createJson(request)))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.success").value(true))
+          .andExpect(jsonPath("$.message").value(ResponseMessage.SEND_EMAIL))
+          .andDo(print())
+          .andDo(restDocs.document(
+            requestFields(
+              fieldWithPath("email").description("사용자 이메일")
+            ),
+            responseFields(
+              fieldWithPath("success").description("성공 여부"),
+              fieldWithPath("message").description("응답 메시지")
+            )
+          ));
+    }
+
+    @Test
+    @DisplayName("이메일 인증 코드 검증 API")
+    void verify_code() throws Exception {
+        // given
+        VerifyEmailAuthCodeRequest request = new VerifyEmailAuthCodeRequest("test@example.com", "123456");
+
+        // when & then
+        mockMvc.perform(post("/email/verify-code")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(createJson(request)))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.success").value(true))
+          .andExpect(jsonPath("$.message").value(ResponseMessage.SUCCESS_EMAIL_VERIFICATION))
+          .andDo(print())
+          .andDo(restDocs.document(
+            requestFields(
+              fieldWithPath("email").description("사용자 이메일"),
+              fieldWithPath("code").description("이메일 인증 코드")
+            ),
+            responseFields(
+              fieldWithPath("success").description("성공 여부"),
+              fieldWithPath("message").description("응답 메시지")
+            )
+          ));
+    }
+}

--- a/src/test/java/com/WearWeather/wear/domain/mail/service/MailServiceTest.java
+++ b/src/test/java/com/WearWeather/wear/domain/mail/service/MailServiceTest.java
@@ -1,10 +1,9 @@
-package com.WearWeather.wear.domain.mail;
+package com.WearWeather.wear.domain.mail.service;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import com.WearWeather.wear.domain.mail.service.MailService;
 import com.WearWeather.wear.domain.user.dto.request.RegisterUserRequest;
 import com.WearWeather.wear.domain.user.service.UserService;
 import com.WearWeather.wear.fixture.UserFixture;

--- a/src/test/java/com/WearWeather/wear/domain/oauth/controller/OAuthControllerTest.java
+++ b/src/test/java/com/WearWeather/wear/domain/oauth/controller/OAuthControllerTest.java
@@ -1,0 +1,63 @@
+package com.WearWeather.wear.domain.oauth.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.WearWeather.wear.document.utils.RestDocsTestSupport;
+import com.WearWeather.wear.domain.auth.dto.response.TokenResponse;
+import com.WearWeather.wear.domain.oauth.infrastructure.kakao.KakaoLoginParam;
+import com.WearWeather.wear.domain.oauth.service.OAuthLoginService;
+import com.WearWeather.wear.global.jwt.JwtCookieManager;
+import com.WearWeather.wear.global.jwt.TokenProvider;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+@MockBean(JpaMetamodelMappingContext.class)
+@WebMvcTest(OAuthController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class OAuthControllerTest extends RestDocsTestSupport {
+
+    @MockBean
+    private OAuthLoginService oAuthLoginService;
+
+    @MockBean
+    private JwtCookieManager jwtCookieManager;
+
+    @MockBean
+    private TokenProvider tokenProvider;
+
+    @Test
+    @DisplayName("카카오 소셜 로그인 API")
+    void kakaoLogin() throws Exception {
+        // given
+        String authorizationCode = "kakao_auth_code";
+        TokenResponse tokenResponse = TokenResponse.of("access-token", "refresh-token");
+
+        given(oAuthLoginService.login(any(KakaoLoginParam.class)))
+          .willReturn(tokenResponse);
+
+        // when & then
+        mockMvc.perform(get("/oauth/kakao")
+            .param("code", authorizationCode))
+          .andExpect(status().isOk())
+          .andDo(print())
+          .andDo(restDocs.document(
+            queryParameters(
+              parameterWithName("code").description("카카오 인가 코드")
+            )
+          ));
+    }
+}

--- a/src/test/java/com/WearWeather/wear/domain/post/controller/PostControllerTest.java
+++ b/src/test/java/com/WearWeather/wear/domain/post/controller/PostControllerTest.java
@@ -1,0 +1,407 @@
+package com.WearWeather.wear.domain.post.controller;
+
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.subsectionWithPath;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.WearWeather.wear.document.utils.RestDocsTestSupport;
+import com.WearWeather.wear.domain.post.dto.request.PostCreateRequest;
+import com.WearWeather.wear.domain.post.dto.request.PostUpdateRequest;
+import com.WearWeather.wear.domain.post.dto.request.PostsByFiltersRequest;
+import com.WearWeather.wear.domain.post.dto.response.PostDetailResponse;
+import com.WearWeather.wear.domain.post.dto.response.PostsByFiltersResponse;
+import com.WearWeather.wear.domain.post.dto.response.PostsByLocationResponse;
+import com.WearWeather.wear.domain.post.dto.response.PostsByMeResponse;
+import com.WearWeather.wear.domain.post.dto.response.PostsByTemperatureResponse;
+import com.WearWeather.wear.domain.post.dto.response.TopLikedPostResponse;
+import com.WearWeather.wear.domain.post.facade.PostCreateFacade;
+import com.WearWeather.wear.domain.post.facade.PostDeleteFacade;
+import com.WearWeather.wear.domain.post.facade.PostReaderFacade;
+import com.WearWeather.wear.domain.post.facade.PostUpdateFacade;
+import com.WearWeather.wear.fixture.PostFixture;
+import com.WearWeather.wear.global.common.ResponseMessage;
+import com.WearWeather.wear.global.jwt.UserIdArgumentResolver;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+@MockBean(JpaMetamodelMappingContext.class)
+@WebMvcTest(PostController.class)
+@AutoConfigureMockMvc(addFilters = false)
+
+public class PostControllerTest extends RestDocsTestSupport {
+
+    @MockBean
+    private PostCreateFacade postCreateFacade;
+
+    @MockBean
+    private PostUpdateFacade postUpdateFacade;
+
+    @MockBean
+    private PostDeleteFacade postDeleteFacade;
+
+    @MockBean
+    private PostReaderFacade postReaderFacade;
+
+    @MockBean
+    private UserIdArgumentResolver loggedInUserArgumentResolver;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        given(loggedInUserArgumentResolver.supportsParameter(any())).willReturn(true);
+        given(loggedInUserArgumentResolver.resolveArgument(any(), any(), any(), any())).willReturn(1L);
+    }
+
+    @Test
+    @DisplayName("게시글 생성 API")
+    void create() throws Exception {
+        // given
+        PostCreateRequest request = PostFixture.createPostRequest();
+
+        given(postCreateFacade.createPost(anyLong(), any())).willReturn(1L);
+
+        // when & then
+        mockMvc.perform(post("/posts")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(createJson(request)))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.postId").value(1L))
+          .andDo(print())
+          .andDo(restDocs.document(
+            requestFields(
+              fieldWithPath("title").description("게시글 제목"),
+              fieldWithPath("content").description("게시글 내용"),
+              fieldWithPath("temperature").description("작성 당시의 기온"),
+              fieldWithPath("gender").description("성별 - MALE 또는 FEMALE"),
+              fieldWithPath("city").description("도시 이름 (예: 서울)"),
+              fieldWithPath("district").description("구 이름 (예: 강남구)"),
+              fieldWithPath("weatherTagIds").description("날씨 태그 ID 리스트"),
+              fieldWithPath("temperatureTagIds").description("온도 태그 ID 리스트"),
+              fieldWithPath("seasonTagId").description("계절 태그 ID"),
+              fieldWithPath("imageIds").description("이미지 ID 리스트")
+            ),
+            responseFields(
+              fieldWithPath("postId").description("생성된 게시글 ID")
+            )
+          ));
+    }
+
+    @Test
+    @DisplayName("좋아요 많은 게시글 조회 API")
+    void getTopLikedPosts() throws Exception {
+        // given
+         List<TopLikedPostResponse> topLikedPosts = PostFixture.getTopLikedPostResponses();
+
+        given(postReaderFacade.getTopLikedPosts(anyLong()))
+          .willReturn(topLikedPosts);
+
+        // when & then
+        mockMvc.perform(get("/posts/top-liked"))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.topLikedPosts[0].postId").value(1L))
+          .andDo(print())
+          .andDo(restDocs.document(
+            responseFields(
+              subsectionWithPath("topLikedPosts").description("좋아요 많은 게시글 리스트"),
+              fieldWithPath("topLikedPosts[].postId").description("게시글 ID"),
+              fieldWithPath("topLikedPosts[].thumbnail").description("썸네일 이미지 URL"),
+              fieldWithPath("topLikedPosts[].location.city").description("도시 이름"),
+              fieldWithPath("topLikedPosts[].location.district").description("구 이름"),
+              fieldWithPath("topLikedPosts[].seasonTag").description("계절 태그"),
+              fieldWithPath("topLikedPosts[].weatherTags").description("날씨 태그 리스트"),
+              fieldWithPath("topLikedPosts[].temperatureTags").description("온도 태그 리스트"),
+              fieldWithPath("topLikedPosts[].likeByUser").description("현재 유저가 좋아요 눌렀는지 여부")
+            )
+          ));
+    }
+
+    @Test
+    @DisplayName("게시글 수정 API")
+    void update() throws Exception {
+        // given
+        Long postId = 1L;
+        PostUpdateRequest request = PostFixture.updatePostRequest();
+
+        // when & then
+        mockMvc.perform(patch("/posts/{postId}", postId)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(createJson(request)))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.success").value(true))
+          .andExpect(jsonPath("$.message").value(ResponseMessage.SUCCESS_UPDATE_POST))
+          .andDo(print())
+          .andDo(restDocs.document(
+            pathParameters(
+              parameterWithName("postId").description("수정할 게시글 ID")
+            ),
+            requestFields(
+              fieldWithPath("title").description("게시글 제목"),
+              fieldWithPath("content").description("게시글 내용"),
+              fieldWithPath("gender").description("성별 - MALE 또는 FEMALE"),
+              fieldWithPath("city").description("도시 이름"),
+              fieldWithPath("district").description("구 이름"),
+              fieldWithPath("weatherTagIds").description("날씨 태그 ID 리스트"),
+              fieldWithPath("temperatureTagIds").description("온도 태그 ID 리스트"),
+              fieldWithPath("seasonTagId").description("계절 태그 ID"),
+              fieldWithPath("imageIds").description("이미지 ID 리스트")
+            ),
+            responseFields(
+              fieldWithPath("success").description("요청 성공 여부"),
+              fieldWithPath("message").description("응답 메시지")
+            )
+          ));
+    }
+
+    @Test
+    @DisplayName("게시글 삭제 API")
+    void delete() throws Exception {
+        // given
+        Long postId = 1L;
+
+        // when & then
+        mockMvc.perform(RestDocumentationRequestBuilders.delete("/posts/{postId}", postId))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.success").value(true))
+          .andExpect(jsonPath("$.message").value(ResponseMessage.SUCCESS_DELETE_POST))
+          .andDo(print())
+          .andDo(restDocs.document(
+            pathParameters(
+              parameterWithName("postId").description("삭제할 게시글 ID")
+            ),
+            responseFields(
+              fieldWithPath("success").description("요청 성공 여부"),
+              fieldWithPath("message").description("응답 메시지")
+            )
+          ));
+    }
+
+    @Test
+    @DisplayName("게시글 상세 조회 API")
+    void getPostDetail() throws Exception {
+        // given
+        Long postId = 1L;
+        PostDetailResponse response = PostFixture.getPostDetailResponse();
+
+        given(postReaderFacade.getPostDetail(anyLong(), eq(postId))).willReturn(response);
+
+        // when & then
+        mockMvc.perform(get("/posts/{postId}", postId))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.title").value(response.getTitle()))
+          .andDo(print())
+          .andDo(restDocs.document(
+            pathParameters(
+              parameterWithName("postId").description("조회할 게시글 ID")
+            ),
+            responseFields(
+              fieldWithPath("nickname").description("작성자 닉네임"),
+              fieldWithPath("date").description("작성 일시"),
+              fieldWithPath("title").description("게시글 제목"),
+              fieldWithPath("content").description("게시글 내용"),
+              fieldWithPath("images.image[].imageId").description("이미지 ID"),
+              fieldWithPath("images.image[].url").description("이미지 URL"),
+              fieldWithPath("location.city").description("도시"),
+              fieldWithPath("location.district").description("구"),
+              fieldWithPath("seasonTag").description("계절 태그"),
+              fieldWithPath("weatherTags").description("날씨 태그 목록"),
+              fieldWithPath("temperatureTags").description("온도 태그 목록"),
+              fieldWithPath("likeByUser").description("사용자 좋아요 여부"),
+              fieldWithPath("likedCount").description("좋아요 수"),
+              fieldWithPath("reportPost").description("신고 여부")
+            )
+          ));
+    }
+
+    @Test
+    @DisplayName("위치 기반 게시글 조회 API")
+    void getPostsByLocation() throws Exception {
+        // given
+        PostsByLocationResponse response = PostFixture.postsByLocationResponse();
+
+        given(postReaderFacade.getPostsByLocation(anyLong(), anyInt(), anyInt(), anyString(), anyString(), any()))
+          .willReturn(response);
+
+        // when & then
+        mockMvc.perform(get("/posts")
+            .queryParam("page", "0")
+            .queryParam("size", "10")
+            .queryParam("city", "서울")
+            .queryParam("district", "강남구")
+            .queryParam("sort", "LATEST"))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.total").value(response.total()))
+          .andDo(print())
+          .andDo(restDocs.document(
+            queryParameters(
+              parameterWithName("page").description("페이지 번호 (0부터 시작)"),
+              parameterWithName("size").description("페이지 크기"),
+              parameterWithName("city").description("도시 이름"),
+              parameterWithName("district").description("구 이름"),
+              parameterWithName("sort").description("정렬 조건: LATEST, LIKED")
+            ),
+            responseFields(
+              fieldWithPath("location.city").description("도시"),
+              fieldWithPath("location.district").description("구"),
+              fieldWithPath("posts[].postId").description("게시글 ID"),
+              fieldWithPath("posts[].thumbnail").description("썸네일 이미지 URL"),
+              fieldWithPath("posts[].seasonTag").description("계절 태그"),
+              fieldWithPath("posts[].weatherTags").description("날씨 태그 목록"),
+              fieldWithPath("posts[].temperatureTags").description("온도 태그 목록"),
+              fieldWithPath("posts[].likeByUser").description("사용자 좋아요 여부"),
+              fieldWithPath("total").description("총 페이지 수")
+            )
+          ));
+    }
+
+    @Test
+    @DisplayName("Tag(지역, 날씨, 온도, 계절) 조건 기반 게시글 검색 API")
+    void searchPostsByFilters() throws Exception {
+        // given
+        PostsByFiltersRequest request = PostFixture.postsByFiltersRequest();
+        PostsByFiltersResponse response = PostFixture.getPostsByFiltersResponse();
+
+        given(postReaderFacade.getPosts(anyLong(), any(PostsByFiltersRequest.class)))
+          .willReturn(response);
+
+        // when & then
+        mockMvc.perform(post("/posts/search")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(createJson(request)))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.total").value(response.getTotal()))
+          .andDo(print())
+          .andDo(restDocs.document(
+            requestFields(
+              fieldWithPath("location[].city").description("도시 ID"),
+              fieldWithPath("location[].district").description("구 ID"),
+              fieldWithPath("seasonTagIds").description("계절 태그 ID 리스트"),
+              fieldWithPath("weatherTagIds").description("날씨 태그 ID 리스트"),
+              fieldWithPath("temperatureTagIds").description("온도 태그 ID 리스트"),
+              fieldWithPath("gender").description("성별 (FEMALE 또는 MALE)"),
+              fieldWithPath("sort").description("정렬 조건: LATEST, LIKED"),
+              fieldWithPath("page").description("페이지 번호 (0부터 시작)"),
+              fieldWithPath("size").description("페이지 크기")
+            ),
+            responseFields(
+              fieldWithPath("posts[].postId").description("게시글 ID"),
+              fieldWithPath("posts[].thumbnail").description("썸네일 이미지 URL"),
+              fieldWithPath("posts[].location.city").description("도시"),
+              fieldWithPath("posts[].location.district").description("구"),
+              fieldWithPath("posts[].seasonTag").description("계절 태그"),
+              fieldWithPath("posts[].weatherTags").description("날씨 태그 리스트"),
+              fieldWithPath("posts[].temperatureTags").description("온도 태그 리스트"),
+              fieldWithPath("posts[].likeByUser").description("사용자 좋아요 여부"),
+              fieldWithPath("posts[].gender").description("성별"),
+              fieldWithPath("total").description("총 페이지 수")
+            )
+          ));
+    }
+
+    @Test
+    @DisplayName("온도 기반 게시글 조회 API")
+    void getPostsByTemperature() throws Exception {
+        // given
+        int tmp = 20;
+        int page = 0;
+        int size = 5;
+
+        PostsByTemperatureResponse response = PostFixture.getPostsByTemperatureResponse();
+
+        given(postReaderFacade.getPostsByTemperature(anyLong(), eq(tmp), eq(page), eq(size)))
+          .willReturn(response);
+
+        // when & then
+        mockMvc.perform(get("/posts/tmp")
+            .param("tmp", String.valueOf(tmp))
+            .param("page", String.valueOf(page))
+            .param("size", String.valueOf(size)))
+          .andExpect(status().isOk())
+          .andDo(print())
+          .andDo(restDocs.document(
+            queryParameters(
+              parameterWithName("tmp").description("현재 온도"),
+              parameterWithName("page").description("페이지 번호"),
+              parameterWithName("size").description("페이지 크기")
+            ),
+            responseFields(
+              fieldWithPath("tmpRangeStart").description("추천 온도 범위 시작"),
+              fieldWithPath("tmpRangeEnd").description("추천 온도 범위 끝"),
+              fieldWithPath("posts[].postId").description("게시글 ID"),
+              fieldWithPath("posts[].thumbnail").description("썸네일 이미지 URL"),
+              fieldWithPath("posts[].location.city").description("도시"),
+              fieldWithPath("posts[].location.district").description("구"),
+              fieldWithPath("posts[].seasonTag").description("계절 태그"),
+              fieldWithPath("posts[].weatherTags").description("날씨 태그 리스트"),
+              fieldWithPath("posts[].temperatureTags").description("온도 태그 리스트"),
+              fieldWithPath("posts[].likeByUser").description("사용자 좋아요 여부"),
+              fieldWithPath("total").description("총 페이지 수")
+            )
+          ));
+    }
+
+    @Test
+    @DisplayName("내가 작성한 게시글 조회 API")
+    void getPostsByMe() throws Exception {
+        // given
+        int page = 0;
+        int size = 5;
+
+        PostsByMeResponse response = PostFixture.getPostsByMeResponse();
+
+        given(postReaderFacade.getPostsByMe(anyLong(), eq(page), eq(size)))
+          .willReturn(response);
+
+        // when & then
+        mockMvc.perform(get("/posts/me")
+            .param("page", String.valueOf(page))
+            .param("size", String.valueOf(size)))
+          .andExpect(status().isOk())
+          .andDo(print())
+          .andDo(restDocs.document(
+            queryParameters(
+              parameterWithName("page").description("페이지 번호"),
+              parameterWithName("size").description("페이지 크기")
+            ),
+            responseFields(
+              fieldWithPath("myPosts[].postId").description("게시글 ID"),
+              fieldWithPath("myPosts[].thumbnail").description("썸네일 이미지 URL"),
+              fieldWithPath("myPosts[].location.city").description("도시"),
+              fieldWithPath("myPosts[].location.district").description("구"),
+              fieldWithPath("myPosts[].seasonTag").description("계절 태그"),
+              fieldWithPath("myPosts[].weatherTags").description("날씨 태그 리스트"),
+              fieldWithPath("myPosts[].temperatureTags").description("온도 태그 리스트"),
+              fieldWithPath("myPosts[].likeByUser").description("사용자 좋아요 여부"),
+              fieldWithPath("myPosts[].reportPost").description("신고 여부"),
+              fieldWithPath("total").description("총 페이지 수")
+            )
+          ));
+    }
+}

--- a/src/test/java/com/WearWeather/wear/domain/postHidden/controller/PostHiddenControllerTest.java
+++ b/src/test/java/com/WearWeather/wear/domain/postHidden/controller/PostHiddenControllerTest.java
@@ -1,0 +1,70 @@
+package com.WearWeather.wear.domain.postHidden.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.WearWeather.wear.document.utils.RestDocsConfig;
+import com.WearWeather.wear.document.utils.RestDocsTestSupport;
+import com.WearWeather.wear.domain.postHidden.service.PostHiddenService;
+import com.WearWeather.wear.global.common.ResponseMessage;
+import com.WearWeather.wear.global.jwt.UserIdArgumentResolver;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+@WebMvcTest(PostHiddenController.class)
+@Import(RestDocsConfig.class)
+@AutoConfigureMockMvc(addFilters = false)
+@MockBean(JpaMetamodelMappingContext.class)
+class PostHiddenControllerTest extends RestDocsTestSupport {
+
+    @MockBean
+    private PostHiddenService postHiddenService;
+
+    @MockBean
+    private UserIdArgumentResolver loggedInUserArgumentResolver;
+
+    @BeforeEach
+    void initMocks() throws Exception {
+        given(loggedInUserArgumentResolver.supportsParameter(any())).willReturn(true);
+        given(loggedInUserArgumentResolver.resolveArgument(any(), any(), any(), any())).willReturn(1L);
+    }
+
+    @Test
+    @DisplayName("게시글 숨김 처리 API")
+    void hidePost() throws Exception {
+        Long postId = 1L;
+
+        mockMvc.perform(post("/posts/{postId}/hide", postId))
+          .andExpect(status().isCreated())
+          .andExpect(header().string("Location", "/posts/" + postId + "/hide"))
+          .andExpect(jsonPath("$.success").value(true))
+          .andExpect(jsonPath("$.message").value(ResponseMessage.SUCCESS_POST_HIDDEN))
+          .andDo(restDocs.document(
+            pathParameters(
+              parameterWithName("postId").description("숨길 게시글 ID")
+            ),
+            responseFields(
+              fieldWithPath("success").description("요청 성공 여부"),
+              fieldWithPath("message").description("응답 메시지")
+            )
+          ));
+    }
+}

--- a/src/test/java/com/WearWeather/wear/domain/postHidden/service/PostHiddenServiceTest.java
+++ b/src/test/java/com/WearWeather/wear/domain/postHidden/service/PostHiddenServiceTest.java
@@ -1,4 +1,4 @@
-package com.WearWeather.wear.domain.postHidden;
+package com.WearWeather.wear.domain.postHidden.service;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.any;
@@ -11,7 +11,6 @@ import static org.mockito.Mockito.when;
 import com.WearWeather.wear.domain.post.service.PostValidationService;
 import com.WearWeather.wear.domain.postHidden.entity.PostHidden;
 import com.WearWeather.wear.domain.postHidden.repository.PostHiddenRepository;
-import com.WearWeather.wear.domain.postHidden.service.PostHiddenService;
 import com.WearWeather.wear.domain.user.service.UserService;
 import com.WearWeather.wear.global.exception.CustomException;
 import com.WearWeather.wear.global.exception.ErrorCode;

--- a/src/test/java/com/WearWeather/wear/domain/postLike/controller/LikeControllerTest.java
+++ b/src/test/java/com/WearWeather/wear/domain/postLike/controller/LikeControllerTest.java
@@ -1,0 +1,152 @@
+package com.WearWeather.wear.domain.postLike.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.WearWeather.wear.document.utils.RestDocsTestSupport;
+import com.WearWeather.wear.domain.post.dto.response.LocationResponse;
+import com.WearWeather.wear.domain.postLike.dto.response.LikedPostByMeResponse;
+import com.WearWeather.wear.domain.postLike.dto.response.LikedPostsByMeResponse;
+import com.WearWeather.wear.domain.postLike.dto.response.TotalLikedCountAfterLike;
+import com.WearWeather.wear.domain.postLike.dto.response.TotalLikedCountAfterUnlike;
+import com.WearWeather.wear.domain.postLike.facade.LikeCreateFacade;
+import com.WearWeather.wear.domain.postLike.facade.LikeDeleteFacade;
+import com.WearWeather.wear.domain.postLike.facade.LikeReaderFacade;
+import com.WearWeather.wear.global.jwt.UserIdArgumentResolver;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+@WebMvcTest(LikeController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@MockBean(JpaMetamodelMappingContext.class)
+class LikeControllerTest extends RestDocsTestSupport {
+
+    @MockBean
+    private LikeReaderFacade likeReaderFacade;
+
+    @MockBean
+    private LikeCreateFacade likeCreateFacade;
+
+    @MockBean
+    private LikeDeleteFacade likeDeleteFacade;
+
+    @MockBean
+    private UserIdArgumentResolver loggedInUserArgumentResolver;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        given(loggedInUserArgumentResolver.supportsParameter(any())).willReturn(true);
+        given(loggedInUserArgumentResolver.resolveArgument(any(), any(), any(), any())).willReturn(1L);
+    }
+
+    @Test
+    @DisplayName("게시글 좋아요 추가 API")
+    void addLike() throws Exception {
+        given(likeCreateFacade.addLike(anyLong(), anyLong()))
+          .willReturn(TotalLikedCountAfterLike.of(10));
+
+        mockMvc.perform(post("/likes/posts/{postId}", 1L))
+          .andExpect(status().isCreated())
+          .andExpect(jsonPath("$.likedCount").value(10))
+          .andDo(print())
+          .andDo(restDocs.document(
+            pathParameters(
+              parameterWithName("postId").description("게시글 ID")
+            ),
+            responseFields(
+              fieldWithPath("likedCount").description("좋아요 수")
+            )
+          ));
+    }
+
+    @Test
+    @DisplayName("게시글 좋아요 취소 API")
+    void removeLike() throws Exception {
+        given(likeDeleteFacade.removeLike(anyLong(), anyLong()))
+          .willReturn(new TotalLikedCountAfterUnlike(7));
+
+        mockMvc.perform(delete("/likes/posts/{postId}", 1L))
+          .andExpect(status().isCreated())
+          .andExpect(jsonPath("$.likedCount").value(7))
+          .andDo(print())
+          .andDo(restDocs.document(
+            pathParameters(
+              parameterWithName("postId").description("게시글 ID")
+            ),
+            responseFields(
+              fieldWithPath("likedCount").description("좋아요 수")
+            )
+          ));
+    }
+
+    @Test
+    @DisplayName("내가 좋아요한 게시글 조회 API")
+    void getLikedPostsByMe() throws Exception {
+        LocationResponse location = LocationResponse.of("서울", "강남구");
+        LikedPostByMeResponse post = LikedPostByMeResponse.of(
+          1L,
+          "thumbnail.jpg",
+          location,
+          Map.of(
+            "SEASON", List.of("봄"),
+            "WEATHER", List.of("맑음", "흐림"),
+            "TEMPERATURE", List.of("따뜻함")
+          ),
+          true
+        );
+        LikedPostsByMeResponse response = LikedPostsByMeResponse.of(List.of(post), 1);
+
+        given(likeReaderFacade.getLikedPostsByMe(anyLong(), eq(0), eq(5)))
+          .willReturn(response);
+
+        mockMvc.perform(get("/likes/posts")
+            .param("page", "0")
+            .param("size", "5"))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.myLikedPosts[0].postId").value(1L))
+          .andExpect(jsonPath("$.myLikedPosts[0].seasonTag").value("봄"))
+          .andExpect(jsonPath("$.total").value(1))
+          .andDo(print())
+          .andDo(restDocs.document(
+            queryParameters(
+              parameterWithName("page").description("페이지 번호"),
+              parameterWithName("size").description("페이지 크기")
+            ),
+            responseFields(
+              fieldWithPath("myLikedPosts[].postId").description("게시글 ID"),
+              fieldWithPath("myLikedPosts[].thumbnail").description("썸네일 이미지 URL"),
+              fieldWithPath("myLikedPosts[].location.city").description("도시 이름"),
+              fieldWithPath("myLikedPosts[].location.district").description("구 이름"),
+              fieldWithPath("myLikedPosts[].seasonTag").description("계절 태그"),
+              fieldWithPath("myLikedPosts[].weatherTags").description("날씨 태그 리스트"),
+              fieldWithPath("myLikedPosts[].temperatureTags").description("온도 태그 리스트"),
+              fieldWithPath("myLikedPosts[].likeByUser").description("유저가 좋아요했는지 여부"),
+              fieldWithPath("total").description("총 페이지 수")
+            )
+          ));
+    }
+}

--- a/src/test/java/com/WearWeather/wear/domain/postReport/controller/PostReportControllerTest.java
+++ b/src/test/java/com/WearWeather/wear/domain/postReport/controller/PostReportControllerTest.java
@@ -1,0 +1,77 @@
+package com.WearWeather.wear.domain.postReport.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.WearWeather.wear.document.utils.RestDocsTestSupport;
+import com.WearWeather.wear.domain.postReport.service.PostReportService;
+import com.WearWeather.wear.global.common.ResponseMessage;
+import com.WearWeather.wear.global.jwt.UserIdArgumentResolver;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+@MockBean(JpaMetamodelMappingContext.class)
+@WebMvcTest(PostReportController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class PostReportControllerTest extends RestDocsTestSupport {
+
+    @MockBean
+    private PostReportService postReportService;
+
+    @MockBean
+    private UserIdArgumentResolver loggedInUserArgumentResolver;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        given(loggedInUserArgumentResolver.supportsParameter(any())).willReturn(true);
+        given(loggedInUserArgumentResolver.resolveArgument(any(), any(), any(), any())).willReturn(1L);
+    }
+
+    @Test
+    @DisplayName("게시글 신고 API")
+    void reportPost() throws Exception {
+        // given
+        Long postId = 1L;
+        String reason = "스팸입니다.";
+
+        // when & then
+        mockMvc.perform(post("/posts/{postId}/report?reason={reason}", postId, reason)
+            .characterEncoding("UTF-8"))
+          .andExpect(status().isCreated())
+          .andExpect(header().string("Location", "/posts/" + postId + "/report"))
+          .andExpect(jsonPath("$.success").value(true))
+          .andExpect(jsonPath("$.message").value(ResponseMessage.SUCCESS_REPORT_POST))
+          .andDo(print())
+          .andDo(restDocs.document(
+            pathParameters(
+              parameterWithName("postId").description("신고할 게시글 ID")
+            ),
+            queryParameters(
+              parameterWithName("reason").description("신고 사유")
+            ),
+            responseFields(
+              fieldWithPath("success").description("요청 성공 여부"),
+              fieldWithPath("message").description("응답 메시지")
+            )
+          ));
+    }
+}

--- a/src/test/java/com/WearWeather/wear/domain/postReport/service/PostReportServiceTest.java
+++ b/src/test/java/com/WearWeather/wear/domain/postReport/service/PostReportServiceTest.java
@@ -1,4 +1,4 @@
-package com.WearWeather.wear.domain.postReport;
+package com.WearWeather.wear.domain.postReport.service;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.any;
@@ -11,7 +11,6 @@ import static org.mockito.Mockito.when;
 import com.WearWeather.wear.domain.post.service.PostValidationService;
 import com.WearWeather.wear.domain.postReport.entity.PostReport;
 import com.WearWeather.wear.domain.postReport.repository.PostReportRepository;
-import com.WearWeather.wear.domain.postReport.service.PostReportService;
 import com.WearWeather.wear.domain.user.service.UserService;
 import com.WearWeather.wear.global.exception.CustomException;
 import com.WearWeather.wear.global.exception.ErrorCode;

--- a/src/test/java/com/WearWeather/wear/domain/storage/controller/AwsS3ControllerTest.java
+++ b/src/test/java/com/WearWeather/wear/domain/storage/controller/AwsS3ControllerTest.java
@@ -1,0 +1,94 @@
+package com.WearWeather.wear.domain.storage.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.multipart;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.partWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.requestParts;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.WearWeather.wear.document.utils.RestDocsTestSupport;
+import com.WearWeather.wear.domain.postImage.service.PostImageService;
+import com.WearWeather.wear.domain.storage.dto.ImageInfoDto;
+import com.WearWeather.wear.domain.storage.service.AwsS3Service;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+@MockBean(JpaMetamodelMappingContext.class)
+@WebMvcTest(AwsS3Controller.class)
+@AutoConfigureMockMvc(addFilters = false)
+class AwsS3ControllerTest extends RestDocsTestSupport {
+
+    @MockBean
+    private AwsS3Service awsS3Service;
+
+    @MockBean
+    private PostImageService postImageService;
+
+    @Test
+    @DisplayName("게시글 이미지 업로드 API")
+    void uploadPostImage() throws Exception {
+        // given
+        MockMultipartFile file = new MockMultipartFile(
+          "file", "image.jpg", MediaType.IMAGE_JPEG_VALUE, "test image content".getBytes()
+        );
+
+        ImageInfoDto imageInfoDto = ImageInfoDto.of("s3-name", "https://s3.bucket.com/image.jpg");
+        given(awsS3Service.upload(any(), eq("post-image"))).willReturn(imageInfoDto);
+        given(postImageService.createPostImage(any(), eq(imageInfoDto))).willReturn(1L);
+
+        // when & then
+        mockMvc.perform(multipart("/s3/post-image")
+            .file(file))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.id").value(1L))
+          .andExpect(jsonPath("$.url").value("https://s3.bucket.com/image.jpg"))
+          .andDo(print())
+          .andDo(restDocs.document(
+            requestParts(
+              partWithName("file").description("업로드할 이미지 파일")
+            ),
+            responseFields(
+              fieldWithPath("id").description("업로드된 이미지 ID"),
+              fieldWithPath("url").description("S3 이미지 URL")
+            )
+          ));
+    }
+
+    @Test
+    @DisplayName("게시글 이미지 삭제 API")
+    void deletePostImage() throws Exception {
+        // given
+        Long imageId = 1L;
+        willDoNothing().given(postImageService).deleteImage(imageId);
+
+        // when & then
+        mockMvc.perform(delete("/s3/post-image/{imageId}", imageId))
+          .andExpect(status().isNoContent())
+          .andDo(print())
+          .andDo(restDocs.document(
+            pathParameters(
+              parameterWithName("imageId").description("삭제할 이미지 ID")
+            )
+          ));
+    }
+}

--- a/src/test/java/com/WearWeather/wear/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/WearWeather/wear/domain/user/controller/UserControllerTest.java
@@ -1,0 +1,245 @@
+package com.WearWeather.wear.domain.user.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.WearWeather.wear.document.utils.RestDocsTestSupport;
+import com.WearWeather.wear.domain.user.dto.request.FindUserEmailRequest;
+import com.WearWeather.wear.domain.user.dto.request.FindUserPasswordRequest;
+import com.WearWeather.wear.domain.user.dto.request.ModifyUserInfoRequest;
+import com.WearWeather.wear.domain.user.dto.request.ModifyUserPasswordRequest;
+import com.WearWeather.wear.domain.user.dto.request.RegisterUserRequest;
+import com.WearWeather.wear.domain.user.dto.response.UserIdForPasswordUpdateResponse;
+import com.WearWeather.wear.domain.user.dto.response.UserInfoResponse;
+import com.WearWeather.wear.domain.user.facade.UserDeleteFacade;
+import com.WearWeather.wear.domain.user.service.UserService;
+import com.WearWeather.wear.global.common.ResponseMessage;
+import com.WearWeather.wear.global.jwt.UserIdArgumentResolver;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.mockito.BDDMockito;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.MediaType;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+@MockBean(JpaMetamodelMappingContext.class)
+@WebMvcTest(UserController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class UserControllerTest extends RestDocsTestSupport {
+
+    @MockBean
+    private UserService userService;
+
+    @MockBean
+    private UserDeleteFacade userDeleteFacade;
+
+    @MockBean
+    private UserIdArgumentResolver loggedInUserArgumentResolver;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        given(loggedInUserArgumentResolver.supportsParameter(any())).willReturn(true);
+        given(loggedInUserArgumentResolver.resolveArgument(any(), any(), any(), any())).willReturn(1L);
+    }
+
+    @Test
+    @DisplayName("회원가입 API")
+    void signup() throws Exception {
+        RegisterUserRequest request = new RegisterUserRequest("test@email.com", "pw1234", "홍길동", "길동이", false);
+
+        mockMvc.perform(post("/users/register")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(createJson(request)))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.success").value(true))
+          .andExpect(jsonPath("$.message").value(ResponseMessage.SUCCESS_USER))
+          .andDo(restDocs.document(
+            requestFields(
+              fieldWithPath("email").description("이메일"),
+              fieldWithPath("password").description("비밀번호"),
+              fieldWithPath("name").description("이름"),
+              fieldWithPath("nickname").description("닉네임"),
+              fieldWithPath("social").description("소셜 로그인 여부") // 여기!
+            )
+            ,
+            responseFields(
+              fieldWithPath("success").description("요청 성공 여부"),
+              fieldWithPath("message").description("응답 메시지")
+            )
+          ));
+    }
+
+    @Test
+    @DisplayName("닉네임 중복 확인 API")
+    void checkDuplicateNickname() throws Exception {
+        String nickname = "길동이";
+        BDDMockito.willDoNothing().given(userService).checkDuplicatedUserNickName(nickname);
+
+        mockMvc.perform(get("/users/nickname-check/{nickname}", nickname))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.available").value(true)) // <-- 수정
+          .andExpect(jsonPath("$.message").value(ResponseMessage.NICKNAME_AVAILABLE))
+          .andDo(restDocs.document(
+            pathParameters(
+              parameterWithName("nickname").description("중복 확인할 닉네임")
+            ),
+            responseFields(
+              fieldWithPath("available").description("사용 가능 여부"), // <-- 수정
+              fieldWithPath("message").description("응답 메시지")
+            )
+          ));
+    }
+
+    @Test
+    @DisplayName("이메일 찾기 API")
+    void findUserEmail() throws Exception {
+        FindUserEmailRequest request = new FindUserEmailRequest("홍길동", "길동이");
+        BDDMockito.given(userService.findUserEmail(any(), any())).willReturn("test@email.com");
+
+        mockMvc.perform(post("/users/email")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(createJson(request)))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.email").value("test@email.com"))
+          .andDo(restDocs.document(
+            requestFields(
+              fieldWithPath("name").description("사용자 이름"),
+              fieldWithPath("nickname").description("사용자 닉네임")
+            ),
+            responseFields(
+              fieldWithPath("email").description("조회된 사용자 이메일")
+            )
+          ));
+    }
+
+    @Test
+    @DisplayName("비밀번호 찾기 API")
+    void findUserPassword() throws Exception {
+        FindUserPasswordRequest request = new FindUserPasswordRequest("test@email.com", "홍길동", "길동이");
+        BDDMockito.given(userService.findUserPassword(any(), any(), any())).willReturn(UserIdForPasswordUpdateResponse.of(1L));
+
+        mockMvc.perform(post("/users/password")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(createJson(request)))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.userId").value(1L))
+          .andDo(restDocs.document(
+            requestFields(
+              fieldWithPath("email").description("사용자 이메일"),
+              fieldWithPath("name").description("사용자 이름"),
+              fieldWithPath("nickname").description("사용자 닉네임")
+            ),
+            responseFields(
+              fieldWithPath("userId").description("조회된 사용자 ID")
+            )
+          ));
+    }
+
+    @Test
+    @DisplayName("비밀번호 변경 API")
+    void modify_user_password() throws Exception {
+        ModifyUserPasswordRequest request = new ModifyUserPasswordRequest(1L, "newPassword123");
+
+        mockMvc.perform(patch("/users/password")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(createJson(request)))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.success").value(true))
+          .andExpect(jsonPath("$.message").value(ResponseMessage.MODIFY_PASSWORD))
+          .andDo(restDocs.document(
+            requestFields(
+              fieldWithPath("userId").description("회원 ID"),
+              fieldWithPath("password").description("변경할 비밀번호")
+            ),
+            responseFields(
+              fieldWithPath("success").description("요청 성공 여부"),
+              fieldWithPath("message").description("응답 메시지")
+            )
+          ));
+    }
+
+    @Test
+    @DisplayName("내 정보 조회 API")
+    void get_user_info() throws Exception {
+        given(userService.getUserInfo(anyLong()))
+          .willReturn(new UserInfoResponse("test@email.com", "홍길동", "길동이", false));
+
+        mockMvc.perform(get("/users/me"))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.email").value("test@email.com"))
+          .andExpect(jsonPath("$.name").value("홍길동"))
+          .andExpect(jsonPath("$.nickname").value("길동이"))
+          .andExpect(jsonPath("$.social").value(false))
+          .andDo(restDocs.document(
+            responseFields(
+              fieldWithPath("email").description("이메일"),
+              fieldWithPath("name").description("이름"),
+              fieldWithPath("nickname").description("닉네임"),
+              fieldWithPath("social").description("소셜 로그인 여부")
+            )
+          ));
+    }
+
+    @Test
+    @DisplayName("내 정보 수정 API")
+    void modify_user_info() throws Exception {
+        ModifyUserInfoRequest request = new ModifyUserInfoRequest("newPassword123", "길동이");
+
+        mockMvc.perform(patch("/users/me")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(createJson(request)))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.success").value(true))
+          .andExpect(jsonPath("$.message").value(ResponseMessage.MODIFY_USERINFO))
+          .andDo(restDocs.document(
+            requestFields(
+              fieldWithPath("password").description("비밀번호"),
+              fieldWithPath("nickname").description("변경할 닉네임")
+            ),
+            responseFields(
+              fieldWithPath("success").description("요청 성공 여부"),
+              fieldWithPath("message").description("응답 메시지")
+            )
+          ));
+    }
+
+    @Test
+    @DisplayName("회원 탈퇴 API")
+    void delete_user() throws Exception {
+        mockMvc.perform(
+            org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders
+              .delete("/users")
+              .queryParam("deleteReason", "서비스가 불편해요"))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.success").value(true))
+          .andExpect(jsonPath("$.message").value(ResponseMessage.SUCCESS_DELETE_USER))
+          .andDo(restDocs.document(
+            queryParameters(
+              parameterWithName("deleteReason").description("회원 탈퇴 사유")
+            ),
+            responseFields(
+              fieldWithPath("success").description("요청 성공 여부"),
+              fieldWithPath("message").description("응답 메시지")
+            )
+          ));
+    }
+}

--- a/src/test/java/com/WearWeather/wear/domain/user/controller/UserDeleteControllerTest.java
+++ b/src/test/java/com/WearWeather/wear/domain/user/controller/UserDeleteControllerTest.java
@@ -1,0 +1,54 @@
+package com.WearWeather.wear.domain.user.controller;
+
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.WearWeather.wear.document.utils.RestDocsTestSupport;
+import com.WearWeather.wear.domain.user.facade.UserDeleteFacade;
+import com.WearWeather.wear.domain.user.service.UserService;
+import com.WearWeather.wear.global.jwt.UserIdArgumentResolver;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+@MockBean(JpaMetamodelMappingContext.class)
+@WebMvcTest(UserDeleteController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class UserDeleteControllerTest extends RestDocsTestSupport {
+
+    @MockBean
+    private UserService userService;
+
+    @MockBean
+    private UserDeleteFacade userDeleteFacade;
+
+    @MockBean
+    private UserIdArgumentResolver loggedInUserArgumentResolver;
+
+    @Test
+    @DisplayName("회원 탈퇴 사유 조회 API")
+    void get_delete_reasons() throws Exception {
+        mockMvc.perform(get("/users/delete-reasons"))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$[0]").value("사용을 잘 안하게 돼요"))
+          .andExpect(jsonPath("$[1]").value("서비스 활성화가 잘 안되어 있어요"))
+          .andExpect(jsonPath("$[2]").value("개인정보 보호를 위해 삭제할 필요가 있어요"))
+          .andExpect(jsonPath("$[3]").value("서비스 기능이 미흡해요"))
+          .andExpect(jsonPath("$[4]").value("오류가 잦아요"))
+          .andDo(restDocs.document(
+            responseFields(
+              fieldWithPath("[].").description("회원 탈퇴 사유 목록")
+            )
+          ));
+    }
+}

--- a/src/test/java/com/WearWeather/wear/domain/weather/controller/WeatherControllerTest.java
+++ b/src/test/java/com/WearWeather/wear/domain/weather/controller/WeatherControllerTest.java
@@ -1,0 +1,131 @@
+package com.WearWeather.wear.domain.weather.controller;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.WearWeather.wear.document.utils.RestDocsTestSupport;
+import com.WearWeather.wear.domain.weather.dto.response.OutfitGuideResponse;
+import com.WearWeather.wear.domain.weather.dto.response.WeatherPerTimeResponse;
+import com.WearWeather.wear.domain.weather.dto.response.WeatherTmpResponse;
+import com.WearWeather.wear.domain.weather.service.WeatherService;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+@MockBean(JpaMetamodelMappingContext.class)
+@WebMvcTest(WeatherController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class WeatherControllerTest extends RestDocsTestSupport {
+
+    @MockBean
+    private WeatherService weatherService;
+
+    @Test
+    @DisplayName("시간대별 날씨 조회 API")
+    void get_weather_per_time() throws Exception {
+        // given
+        double longitude = 127.1234;
+        double latitude = 37.1234;
+
+        given(weatherService.weatherTime(longitude, latitude))
+          .willReturn(WeatherPerTimeResponse.of("24.0", "맑음", "선선한 날씨입니다."));
+
+        // when & then
+        mockMvc.perform(get("/weather/time")
+            .param("longitude", String.valueOf(longitude))
+            .param("latitude", String.valueOf(latitude)))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.currentTemp").value("24.0"))
+          .andExpect(jsonPath("$.weatherType").value("맑음"))
+          .andExpect(jsonPath("$.weatherMessage").value("선선한 날씨입니다."))
+          .andDo(restDocs.document(
+            queryParameters(
+              parameterWithName("longitude").description("경도"),
+              parameterWithName("latitude").description("위도")
+            ),
+            responseFields(
+              fieldWithPath("currentTemp").description("현재 기온"),
+              fieldWithPath("weatherType").description("날씨 유형"),
+              fieldWithPath("weatherMessage").description("날씨 메시지")
+            )
+          ));
+    }
+
+    @Test
+    @DisplayName("최저/최고 기온 조회 API")
+    void get_weather_tmp() throws Exception {
+        // given
+        double longitude = 127.1234;
+        double latitude = 37.1234;
+
+        given(weatherService.weatherTmp(longitude, latitude))
+          .willReturn(WeatherTmpResponse.of("18.0", "27.0"));
+
+        // when & then
+        mockMvc.perform(get("/weather/tmp")
+            .param("longitude", String.valueOf(longitude))
+            .param("latitude", String.valueOf(latitude)))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.minTemp").value("18.0"))
+          .andExpect(jsonPath("$.maxTemp").value("27.0"))
+          .andDo(restDocs.document(
+            queryParameters(
+              parameterWithName("longitude").description("경도"),
+              parameterWithName("latitude").description("위도")
+            ),
+            responseFields(
+              fieldWithPath("minTemp").description("최저 기온"),
+              fieldWithPath("maxTemp").description("최고 기온")
+            )
+          ));
+    }
+
+    @Test
+    @DisplayName("기온 기반 옷차림 가이드 조회 API")
+    void get_outfit_guide() throws Exception {
+        // given
+        int tmp = 23;
+
+        given(weatherService.getOutfitGuide(tmp))
+          .willReturn(OutfitGuideResponse.of(
+            "간절기",
+            "가벼운 겉옷이 필요해요.",
+            "얇은 니트와 청바지",
+            List.of("image1.jpg", "image2.jpg")
+          ));
+
+        // when & then
+        mockMvc.perform(get("/weather/guide/outfit")
+            .param("tmp", String.valueOf(tmp)))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.category").value("간절기"))
+          .andExpect(jsonPath("$.categorySentence").value("가벼운 겉옷이 필요해요."))
+          .andExpect(jsonPath("$.outfit").value("얇은 니트와 청바지"))
+          .andExpect(jsonPath("$.outfitImages").isArray())
+          .andDo(restDocs.document(
+            queryParameters(
+              parameterWithName("tmp").description("현재 기온")
+            ),
+            responseFields(
+              fieldWithPath("category").description("카테고리"),
+              fieldWithPath("categorySentence").description("추천 문구"),
+              fieldWithPath("outfit").description("추천 옷차림"),
+              fieldWithPath("outfitImages").description("추천 옷차림 이미지 리스트")
+            )
+          ));
+    }
+}

--- a/src/test/java/com/WearWeather/wear/fixture/PostFixture.java
+++ b/src/test/java/com/WearWeather/wear/fixture/PostFixture.java
@@ -1,0 +1,204 @@
+package com.WearWeather.wear.fixture;
+
+import com.WearWeather.wear.domain.post.dto.request.LocationRequest;
+import com.WearWeather.wear.domain.post.dto.request.PostCreateRequest;
+import com.WearWeather.wear.domain.post.dto.request.PostUpdateRequest;
+import com.WearWeather.wear.domain.post.dto.request.PostsByFiltersRequest;
+import com.WearWeather.wear.domain.post.dto.response.ImageDetailResponse;
+import com.WearWeather.wear.domain.post.dto.response.ImagesResponse;
+import com.WearWeather.wear.domain.post.dto.response.LocationResponse;
+import com.WearWeather.wear.domain.post.dto.response.PostByLocationResponse;
+import com.WearWeather.wear.domain.post.dto.response.PostByMeResponse;
+import com.WearWeather.wear.domain.post.dto.response.PostByTemperatureResponse;
+import com.WearWeather.wear.domain.post.dto.response.PostDetailResponse;
+import com.WearWeather.wear.domain.post.dto.response.PostWithLocationName;
+import com.WearWeather.wear.domain.post.dto.response.PostsByFiltersResponse;
+import com.WearWeather.wear.domain.post.dto.response.PostsByLocationResponse;
+import com.WearWeather.wear.domain.post.dto.response.PostsByMeResponse;
+import com.WearWeather.wear.domain.post.dto.response.PostsByTemperatureResponse;
+import com.WearWeather.wear.domain.post.dto.response.SearchPostResponse;
+import com.WearWeather.wear.domain.post.dto.response.TopLikedPostResponse;
+import com.WearWeather.wear.domain.post.entity.Gender;
+import com.WearWeather.wear.domain.post.entity.SortType;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class PostFixture {
+
+    public static final String title = "오늘의 코디";
+    public static final String content = "설명";
+    public static final int temperature = 20;
+    public static final String gender = "FEMALE";
+    public static final String city = "서울";
+    public static final String district = "강남구";
+
+    public static final Set<Long> weatherTagIds = Set.of(1L);
+    public static final Set<Long> temperatureTagIds = Set.of(2L);
+    public static final List<Long> seasonTagIds = List.of(2L);
+
+
+    public static final List<Long> weatherTagIdList = List.of(2L);
+    public static final List<Long> temperatureTagIdList = List.of(2L);
+
+
+    public static final Long seasonTagId = 3L;
+    public static final List<Long> imageIds = List.of(10L);
+
+    public static PostCreateRequest createPostRequest() {
+        return PostCreateRequest.builder()
+          .title(title)
+          .content(content)
+          .temperature(temperature)
+          .gender(gender)
+          .city(city)
+          .district(district)
+          .weatherTagIds(weatherTagIds)
+          .temperatureTagIds(temperatureTagIds)
+          .seasonTagId(seasonTagId)
+          .imageIds(imageIds)
+          .build();
+    }
+
+    public static PostUpdateRequest updatePostRequest() {
+        return PostUpdateRequest.builder()
+          .title(title)
+          .content(content)
+          .city(city)
+          .district(district)
+          .gender(Gender.FEMALE)
+          .weatherTagIds(weatherTagIds)
+          .temperatureTagIds(temperatureTagIds)
+          .seasonTagId(seasonTagId)
+          .imageIds(imageIds)
+          .build();
+    }
+
+    public static PostDetailResponse getPostDetailResponse() {
+        return PostDetailResponse.builder()
+          .nickname("건희")
+          .date("2024.01.01 10:00")
+          .title(title)
+          .content(content)
+          .images(ImagesResponse.of(List.of(
+            ImageDetailResponse.of(1L, "https://image.url/1.jpg"),
+            ImageDetailResponse.of(2L, "https://image.url/2.jpg")
+          )))
+          .location(LocationResponse.of(city, district))
+          .seasonTag("봄")
+          .weatherTags(List.of("맑음"))
+          .temperatureTags(List.of("선선함"))
+          .likeByUser(true)
+          .likedCount(10)
+          .reportPost(false)
+          .build();
+    }
+
+    public static PostsByLocationResponse postsByLocationResponse() {
+        return PostsByLocationResponse.of(
+          LocationResponse.of(city, district),
+          List.of(
+            PostByLocationResponse.of(
+              1L,
+              "https://image.url/thumbnail.jpg",
+              Map.of(
+                "SEASON", List.of("봄"),
+                "WEATHER", List.of("맑음"),
+                "TEMPERATURE", List.of("선선함")
+              ),
+              true
+            )
+          ),
+          5
+        );
+    }
+
+    public static PostsByFiltersRequest postsByFiltersRequest() {
+        return PostsByFiltersRequest.builder()
+          .page(0)
+          .size(10)
+          .location(List.of(new LocationRequest(1L, 2L))) // 예시로 cityId = 1, districtId = 2
+          .seasonTagIds(List.of(seasonTagId))
+          .weatherTagIds(List.copyOf(weatherTagIds))
+          .temperatureTagIds(List.copyOf(temperatureTagIds))
+          .gender(gender) // 문자열 "FEMALE"
+          .sort(SortType.LATEST)
+          .build();
+    }
+
+
+    public static PostsByFiltersResponse getPostsByFiltersResponse() {
+        return PostsByFiltersResponse.of(
+          List.of(
+            SearchPostResponse.of(
+              new PostWithLocationName(
+                1L,
+                10L,
+                city,
+                district,
+                Gender.FEMALE
+              ),
+              "https://image.url/thumbnail.jpg",
+              Map.of(
+                "SEASON", List.of("봄"),
+                "WEATHER", List.of("맑음"),
+                "TEMPERATURE", List.of("선선함")
+              ),
+              true,
+              Gender.FEMALE
+            )
+          ),
+          3
+        );
+    }
+
+    public static PostsByTemperatureResponse getPostsByTemperatureResponse() {
+        return PostsByTemperatureResponse.of(
+          18, 22,
+          List.of(PostByTemperatureResponse.of(
+            1L,
+            "https://image.url/1.jpg",
+            LocationResponse.of("서울", "강남구"),
+            Map.of(
+              "SEASON", List.of("봄"),
+              "WEATHER", List.of("맑음"),
+              "TEMPERATURE", List.of("선선함")
+            ),
+            true
+          )),
+          3
+        );
+    }
+
+    public static PostsByMeResponse getPostsByMeResponse() {
+        return PostsByMeResponse.of(
+          List.of(PostByMeResponse.of(
+            1L,
+            "https://image.url/1.jpg",
+            LocationResponse.of("서울", "강남구"),
+            Map.of(
+              "SEASON", List.of("봄"),
+              "WEATHER", List.of("맑음"),
+              "TEMPERATURE", List.of("선선함")
+            ),
+            true,
+            false
+          )),
+          2
+        );
+    }
+
+    public static List<TopLikedPostResponse> getTopLikedPostResponses() {
+        return List.of(
+          TopLikedPostResponse.builder()
+            .postId(1L)
+            .thumbnail("https://image.com/1.jpg")
+            .location(new LocationResponse("서울", "강남구"))
+            .seasonTag("겨울")
+            .weatherTags(List.of("눈", "흐림"))
+            .temperatureTags(List.of("0~5도"))
+            .likeByUser(true)
+            .build()
+        );
+    }
+}


### PR DESCRIPTION
## 🚩 연관 이슈
close #128 

## 🗣️ 작업 개요
- 기존 Notion을 통해 API 명세서를 관리했었다.
-  API 리팩토링 과정에서 문서화 부족으로 혼선이 발생하여 어려움을 겪게 되었다.
- 이를 개선하고자 테스트 코드 기반으로 문서를 최신 상태로 유지하는 방식으로 전환하여 명세 신뢰도 높이고자 Spring RestDocs 도입


## 📝 작업 내용
- 도메인별 API에 대한 통합 테스트 코드를 작성하여 RestDocs 기반 문서 자동화 적용
- 각 도메인별로 .adoc 파일을 생성하여 API 문서를 구성
- index.adoc를 통해 전체 API를 한 눈에 확인 가능하며, 각 도메인 문서로 링크 연결 가능
- 테스트 작성 시 중복되는 설정(ObjectMapper, MockMvc, document 등)을 분리하여 
  RestDocsConfig, RestDocsSupport 클래스로 통합 관리
- 직렬화된 JSON이 보기 좋게 출력되도록 ObjectMapper Pretty Print 설정 추가
