### PR TITLE
API 문서화 테스트 코드에서 불필요한 어노테이션 및 중복 코드 제거

### DIFF
--- a/src/main/java/com/WearWeather/wear/WearApplication.java
+++ b/src/main/java/com/WearWeather/wear/WearApplication.java
@@ -5,7 +5,6 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
-@EnableJpaAuditing
 @EnableScheduling
 @SpringBootApplication
 public class WearApplication {

--- a/src/main/java/com/WearWeather/wear/global/config/JpaAuditingConfiguration.java
+++ b/src/main/java/com/WearWeather/wear/global/config/JpaAuditingConfiguration.java
@@ -1,0 +1,10 @@
+package com.WearWeather.wear.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfiguration {
+    
+}

--- a/src/test/java/com/WearWeather/wear/domain/location/controller/LocationControllerTest.java
+++ b/src/test/java/com/WearWeather/wear/domain/location/controller/LocationControllerTest.java
@@ -26,13 +26,12 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.security.test.context.support.WithMockUser;
 import reactor.core.publisher.Mono;
 
-@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
-@SuppressWarnings("NonAsciiCharacters")
+@WithMockUser
 @WebMvcTest(LocationController.class)
-@AutoConfigureMockMvc(addFilters = false)
-@MockBean(JpaMetamodelMappingContext.class)
+@AutoConfigureMockMvc
 class LocationControllerTest extends RestDocsTestSupport {
 
     @MockBean
@@ -43,8 +42,8 @@ class LocationControllerTest extends RestDocsTestSupport {
     void getLocationData() throws Exception {
         mockMvc.perform(get("/basic-location"))
           .andExpect(status().isOk())
-          .andDo(print())
-          .andDo(restDocs.document());
+          .andDo(
+            restDocs.document());
     }
 
     @Test
@@ -61,19 +60,19 @@ class LocationControllerTest extends RestDocsTestSupport {
           .andExpect(status().isOk())
           .andExpect(jsonPath("$.city").value("서울"))
           .andExpect(jsonPath("$.district").value("강남구"))
-          .andDo(print())
-          .andDo(restDocs.document(
-            queryParameters(
-              parameterWithName("longitude").description("경도"),
-              parameterWithName("latitude").description("위도")
-            ),
-            responseFields(
-              fieldWithPath("city").description("도시 이름"),
-              fieldWithPath("cityId").description("도시 ID"),
-              fieldWithPath("district").description("구 이름"),
-              fieldWithPath("districtId").description("구 ID")
-            )
-          ));
+          .andDo(
+            restDocs.document(
+              queryParameters(
+                parameterWithName("longitude").description("경도"),
+                parameterWithName("latitude").description("위도")
+              ),
+              responseFields(
+                fieldWithPath("city").description("도시 이름"),
+                fieldWithPath("cityId").description("도시 ID"),
+                fieldWithPath("district").description("구 이름"),
+                fieldWithPath("districtId").description("구 ID")
+              )
+            ));
     }
 
     @Test
@@ -90,21 +89,21 @@ class LocationControllerTest extends RestDocsTestSupport {
             .param("address", "서울"))
           .andExpect(status().isOk())
           .andExpect(jsonPath("$[0].address_name").value("서울 강남구"))
-          .andDo(print())
-          .andDo(restDocs.document(
-            queryParameters(
-              parameterWithName("address").description("검색할 주소 문자열")
-            ),
-            responseFields(
-              fieldWithPath("[].address_name").description("전체 주소"),
-              fieldWithPath("[].longitude").description("경도"),
-              fieldWithPath("[].latitude").description("위도"),
-              fieldWithPath("[].cityName").description("도시 이름"),
-              fieldWithPath("[].cityId").description("도시 ID"),
-              fieldWithPath("[].districtName").description("구 이름"),
-              fieldWithPath("[].districtId").description("구 ID")
-            )
-          ));
+          .andDo(
+            restDocs.document(
+              queryParameters(
+                parameterWithName("address").description("검색할 주소 문자열")
+              ),
+              responseFields(
+                fieldWithPath("[].address_name").description("전체 주소"),
+                fieldWithPath("[].longitude").description("경도"),
+                fieldWithPath("[].latitude").description("위도"),
+                fieldWithPath("[].cityName").description("도시 이름"),
+                fieldWithPath("[].cityId").description("도시 ID"),
+                fieldWithPath("[].districtName").description("구 이름"),
+                fieldWithPath("[].districtId").description("구 ID")
+              )
+            ));
     }
 
     @Test
@@ -125,14 +124,14 @@ class LocationControllerTest extends RestDocsTestSupport {
           .andExpect(jsonPath("$.region[0].cityId").value(1L))
           .andExpect(jsonPath("$.region[0].cityName").value("서울"))
           .andExpect(jsonPath("$.region[0].district[0].districtName").value("강남구"))
-          .andDo(print())
-          .andDo(restDocs.document(
-            responseFields(
-              fieldWithPath("region[].cityId").description("도시 ID"),
-              fieldWithPath("region[].cityName").description("도시 이름"),
-              fieldWithPath("region[].district[].districtId").description("구 ID"),
-              fieldWithPath("region[].district[].districtName").description("구 이름")
-            )
-          ));
+          .andDo(
+            restDocs.document(
+              responseFields(
+                fieldWithPath("region[].cityId").description("도시 ID"),
+                fieldWithPath("region[].cityName").description("도시 이름"),
+                fieldWithPath("region[].district[].districtId").description("구 ID"),
+                fieldWithPath("region[].district[].districtName").description("구 이름")
+              )
+            ));
     }
 }

--- a/src/test/java/com/WearWeather/wear/domain/mail/controller/EmailControllerTest.java
+++ b/src/test/java/com/WearWeather/wear/domain/mail/controller/EmailControllerTest.java
@@ -22,13 +22,11 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
 
-
-@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
-@SuppressWarnings("NonAsciiCharacters")
-@MockBean(JpaMetamodelMappingContext.class)
+@WithMockUser
 @WebMvcTest(EmailController.class)
-@AutoConfigureMockMvc(addFilters = false)
+@AutoConfigureMockMvc
 class EmailControllerTest extends RestDocsTestSupport {
 
     @MockBean
@@ -47,16 +45,16 @@ class EmailControllerTest extends RestDocsTestSupport {
           .andExpect(status().isOk())
           .andExpect(jsonPath("$.success").value(true))
           .andExpect(jsonPath("$.message").value(ResponseMessage.SEND_EMAIL))
-          .andDo(print())
-          .andDo(restDocs.document(
-            requestFields(
-              fieldWithPath("email").description("사용자 이메일")
-            ),
-            responseFields(
-              fieldWithPath("success").description("성공 여부"),
-              fieldWithPath("message").description("응답 메시지")
-            )
-          ));
+          .andDo(
+            restDocs.document(
+              requestFields(
+                fieldWithPath("email").description("사용자 이메일")
+              ),
+              responseFields(
+                fieldWithPath("success").description("성공 여부"),
+                fieldWithPath("message").description("응답 메시지")
+              )
+            ));
     }
 
     @Test
@@ -72,16 +70,16 @@ class EmailControllerTest extends RestDocsTestSupport {
           .andExpect(status().isOk())
           .andExpect(jsonPath("$.success").value(true))
           .andExpect(jsonPath("$.message").value(ResponseMessage.SUCCESS_EMAIL_VERIFICATION))
-          .andDo(print())
-          .andDo(restDocs.document(
-            requestFields(
-              fieldWithPath("email").description("사용자 이메일"),
-              fieldWithPath("code").description("이메일 인증 코드")
-            ),
-            responseFields(
-              fieldWithPath("success").description("성공 여부"),
-              fieldWithPath("message").description("응답 메시지")
-            )
-          ));
+          .andDo(
+            restDocs.document(
+              requestFields(
+                fieldWithPath("email").description("사용자 이메일"),
+                fieldWithPath("code").description("이메일 인증 코드")
+              ),
+              responseFields(
+                fieldWithPath("success").description("성공 여부"),
+                fieldWithPath("message").description("응답 메시지")
+              )
+            ));
     }
 }

--- a/src/test/java/com/WearWeather/wear/domain/oauth/controller/OAuthControllerTest.java
+++ b/src/test/java/com/WearWeather/wear/domain/oauth/controller/OAuthControllerTest.java
@@ -22,12 +22,11 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.security.test.context.support.WithMockUser;
 
-@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
-@SuppressWarnings("NonAsciiCharacters")
-@MockBean(JpaMetamodelMappingContext.class)
+@WithMockUser
 @WebMvcTest(OAuthController.class)
-@AutoConfigureMockMvc(addFilters = false)
+@AutoConfigureMockMvc
 class OAuthControllerTest extends RestDocsTestSupport {
 
     @MockBean
@@ -53,11 +52,11 @@ class OAuthControllerTest extends RestDocsTestSupport {
         mockMvc.perform(get("/oauth/kakao")
             .param("code", authorizationCode))
           .andExpect(status().isOk())
-          .andDo(print())
-          .andDo(restDocs.document(
-            queryParameters(
-              parameterWithName("code").description("카카오 인가 코드")
-            )
-          ));
+          .andDo(
+            restDocs.document(
+              queryParameters(
+                parameterWithName("code").description("카카오 인가 코드")
+              )
+            ));
     }
 }

--- a/src/test/java/com/WearWeather/wear/domain/post/controller/PostControllerTest.java
+++ b/src/test/java/com/WearWeather/wear/domain/post/controller/PostControllerTest.java
@@ -50,13 +50,11 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.security.test.context.support.WithMockUser;
 
-@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
-@SuppressWarnings("NonAsciiCharacters")
-@MockBean(JpaMetamodelMappingContext.class)
+@WithMockUser
 @WebMvcTest(PostController.class)
-@AutoConfigureMockMvc(addFilters = false)
-
+@AutoConfigureMockMvc
 public class PostControllerTest extends RestDocsTestSupport {
 
     @MockBean
@@ -94,31 +92,31 @@ public class PostControllerTest extends RestDocsTestSupport {
             .content(createJson(request)))
           .andExpect(status().isOk())
           .andExpect(jsonPath("$.postId").value(1L))
-          .andDo(print())
-          .andDo(restDocs.document(
-            requestFields(
-              fieldWithPath("title").description("게시글 제목"),
-              fieldWithPath("content").description("게시글 내용"),
-              fieldWithPath("temperature").description("작성 당시의 기온"),
-              fieldWithPath("gender").description("성별 - MALE 또는 FEMALE"),
-              fieldWithPath("city").description("도시 이름 (예: 서울)"),
-              fieldWithPath("district").description("구 이름 (예: 강남구)"),
-              fieldWithPath("weatherTagIds").description("날씨 태그 ID 리스트"),
-              fieldWithPath("temperatureTagIds").description("온도 태그 ID 리스트"),
-              fieldWithPath("seasonTagId").description("계절 태그 ID"),
-              fieldWithPath("imageIds").description("이미지 ID 리스트")
-            ),
-            responseFields(
-              fieldWithPath("postId").description("생성된 게시글 ID")
-            )
-          ));
+          .andDo(
+            restDocs.document(
+              requestFields(
+                fieldWithPath("title").description("게시글 제목"),
+                fieldWithPath("content").description("게시글 내용"),
+                fieldWithPath("temperature").description("작성 당시의 기온"),
+                fieldWithPath("gender").description("성별 - MALE 또는 FEMALE"),
+                fieldWithPath("city").description("도시 이름 (예: 서울)"),
+                fieldWithPath("district").description("구 이름 (예: 강남구)"),
+                fieldWithPath("weatherTagIds").description("날씨 태그 ID 리스트"),
+                fieldWithPath("temperatureTagIds").description("온도 태그 ID 리스트"),
+                fieldWithPath("seasonTagId").description("계절 태그 ID"),
+                fieldWithPath("imageIds").description("이미지 ID 리스트")
+              ),
+              responseFields(
+                fieldWithPath("postId").description("생성된 게시글 ID")
+              )
+            ));
     }
 
     @Test
     @DisplayName("좋아요 많은 게시글 조회 API")
     void getTopLikedPosts() throws Exception {
         // given
-         List<TopLikedPostResponse> topLikedPosts = PostFixture.getTopLikedPostResponses();
+        List<TopLikedPostResponse> topLikedPosts = PostFixture.getTopLikedPostResponses();
 
         given(postReaderFacade.getTopLikedPosts(anyLong()))
           .willReturn(topLikedPosts);
@@ -127,20 +125,20 @@ public class PostControllerTest extends RestDocsTestSupport {
         mockMvc.perform(get("/posts/top-liked"))
           .andExpect(status().isOk())
           .andExpect(jsonPath("$.topLikedPosts[0].postId").value(1L))
-          .andDo(print())
-          .andDo(restDocs.document(
-            responseFields(
-              subsectionWithPath("topLikedPosts").description("좋아요 많은 게시글 리스트"),
-              fieldWithPath("topLikedPosts[].postId").description("게시글 ID"),
-              fieldWithPath("topLikedPosts[].thumbnail").description("썸네일 이미지 URL"),
-              fieldWithPath("topLikedPosts[].location.city").description("도시 이름"),
-              fieldWithPath("topLikedPosts[].location.district").description("구 이름"),
-              fieldWithPath("topLikedPosts[].seasonTag").description("계절 태그"),
-              fieldWithPath("topLikedPosts[].weatherTags").description("날씨 태그 리스트"),
-              fieldWithPath("topLikedPosts[].temperatureTags").description("온도 태그 리스트"),
-              fieldWithPath("topLikedPosts[].likeByUser").description("현재 유저가 좋아요 눌렀는지 여부")
-            )
-          ));
+          .andDo(
+            restDocs.document(
+              responseFields(
+                subsectionWithPath("topLikedPosts").description("좋아요 많은 게시글 리스트"),
+                fieldWithPath("topLikedPosts[].postId").description("게시글 ID"),
+                fieldWithPath("topLikedPosts[].thumbnail").description("썸네일 이미지 URL"),
+                fieldWithPath("topLikedPosts[].location.city").description("도시 이름"),
+                fieldWithPath("topLikedPosts[].location.district").description("구 이름"),
+                fieldWithPath("topLikedPosts[].seasonTag").description("계절 태그"),
+                fieldWithPath("topLikedPosts[].weatherTags").description("날씨 태그 리스트"),
+                fieldWithPath("topLikedPosts[].temperatureTags").description("온도 태그 리스트"),
+                fieldWithPath("topLikedPosts[].likeByUser").description("현재 유저가 좋아요 눌렀는지 여부")
+              )
+            ));
     }
 
     @Test
@@ -157,7 +155,6 @@ public class PostControllerTest extends RestDocsTestSupport {
           .andExpect(status().isOk())
           .andExpect(jsonPath("$.success").value(true))
           .andExpect(jsonPath("$.message").value(ResponseMessage.SUCCESS_UPDATE_POST))
-          .andDo(print())
           .andDo(restDocs.document(
             pathParameters(
               parameterWithName("postId").description("수정할 게시글 ID")
@@ -191,16 +188,16 @@ public class PostControllerTest extends RestDocsTestSupport {
           .andExpect(status().isOk())
           .andExpect(jsonPath("$.success").value(true))
           .andExpect(jsonPath("$.message").value(ResponseMessage.SUCCESS_DELETE_POST))
-          .andDo(print())
-          .andDo(restDocs.document(
-            pathParameters(
-              parameterWithName("postId").description("삭제할 게시글 ID")
-            ),
-            responseFields(
-              fieldWithPath("success").description("요청 성공 여부"),
-              fieldWithPath("message").description("응답 메시지")
-            )
-          ));
+          .andDo(
+            restDocs.document(
+              pathParameters(
+                parameterWithName("postId").description("삭제할 게시글 ID")
+              ),
+              responseFields(
+                fieldWithPath("success").description("요청 성공 여부"),
+                fieldWithPath("message").description("응답 메시지")
+              )
+            ));
     }
 
     @Test
@@ -216,28 +213,28 @@ public class PostControllerTest extends RestDocsTestSupport {
         mockMvc.perform(get("/posts/{postId}", postId))
           .andExpect(status().isOk())
           .andExpect(jsonPath("$.title").value(response.getTitle()))
-          .andDo(print())
-          .andDo(restDocs.document(
-            pathParameters(
-              parameterWithName("postId").description("조회할 게시글 ID")
-            ),
-            responseFields(
-              fieldWithPath("nickname").description("작성자 닉네임"),
-              fieldWithPath("date").description("작성 일시"),
-              fieldWithPath("title").description("게시글 제목"),
-              fieldWithPath("content").description("게시글 내용"),
-              fieldWithPath("images.image[].imageId").description("이미지 ID"),
-              fieldWithPath("images.image[].url").description("이미지 URL"),
-              fieldWithPath("location.city").description("도시"),
-              fieldWithPath("location.district").description("구"),
-              fieldWithPath("seasonTag").description("계절 태그"),
-              fieldWithPath("weatherTags").description("날씨 태그 목록"),
-              fieldWithPath("temperatureTags").description("온도 태그 목록"),
-              fieldWithPath("likeByUser").description("사용자 좋아요 여부"),
-              fieldWithPath("likedCount").description("좋아요 수"),
-              fieldWithPath("reportPost").description("신고 여부")
-            )
-          ));
+          .andDo(
+            restDocs.document(
+              pathParameters(
+                parameterWithName("postId").description("조회할 게시글 ID")
+              ),
+              responseFields(
+                fieldWithPath("nickname").description("작성자 닉네임"),
+                fieldWithPath("date").description("작성 일시"),
+                fieldWithPath("title").description("게시글 제목"),
+                fieldWithPath("content").description("게시글 내용"),
+                fieldWithPath("images.image[].imageId").description("이미지 ID"),
+                fieldWithPath("images.image[].url").description("이미지 URL"),
+                fieldWithPath("location.city").description("도시"),
+                fieldWithPath("location.district").description("구"),
+                fieldWithPath("seasonTag").description("계절 태그"),
+                fieldWithPath("weatherTags").description("날씨 태그 목록"),
+                fieldWithPath("temperatureTags").description("온도 태그 목록"),
+                fieldWithPath("likeByUser").description("사용자 좋아요 여부"),
+                fieldWithPath("likedCount").description("좋아요 수"),
+                fieldWithPath("reportPost").description("신고 여부")
+              )
+            ));
     }
 
     @Test
@@ -258,27 +255,27 @@ public class PostControllerTest extends RestDocsTestSupport {
             .queryParam("sort", "LATEST"))
           .andExpect(status().isOk())
           .andExpect(jsonPath("$.total").value(response.total()))
-          .andDo(print())
-          .andDo(restDocs.document(
-            queryParameters(
-              parameterWithName("page").description("페이지 번호 (0부터 시작)"),
-              parameterWithName("size").description("페이지 크기"),
-              parameterWithName("city").description("도시 이름"),
-              parameterWithName("district").description("구 이름"),
-              parameterWithName("sort").description("정렬 조건: LATEST, LIKED")
-            ),
-            responseFields(
-              fieldWithPath("location.city").description("도시"),
-              fieldWithPath("location.district").description("구"),
-              fieldWithPath("posts[].postId").description("게시글 ID"),
-              fieldWithPath("posts[].thumbnail").description("썸네일 이미지 URL"),
-              fieldWithPath("posts[].seasonTag").description("계절 태그"),
-              fieldWithPath("posts[].weatherTags").description("날씨 태그 목록"),
-              fieldWithPath("posts[].temperatureTags").description("온도 태그 목록"),
-              fieldWithPath("posts[].likeByUser").description("사용자 좋아요 여부"),
-              fieldWithPath("total").description("총 페이지 수")
-            )
-          ));
+          .andDo(
+            restDocs.document(
+              queryParameters(
+                parameterWithName("page").description("페이지 번호 (0부터 시작)"),
+                parameterWithName("size").description("페이지 크기"),
+                parameterWithName("city").description("도시 이름"),
+                parameterWithName("district").description("구 이름"),
+                parameterWithName("sort").description("정렬 조건: LATEST, LIKED")
+              ),
+              responseFields(
+                fieldWithPath("location.city").description("도시"),
+                fieldWithPath("location.district").description("구"),
+                fieldWithPath("posts[].postId").description("게시글 ID"),
+                fieldWithPath("posts[].thumbnail").description("썸네일 이미지 URL"),
+                fieldWithPath("posts[].seasonTag").description("계절 태그"),
+                fieldWithPath("posts[].weatherTags").description("날씨 태그 목록"),
+                fieldWithPath("posts[].temperatureTags").description("온도 태그 목록"),
+                fieldWithPath("posts[].likeByUser").description("사용자 좋아요 여부"),
+                fieldWithPath("total").description("총 페이지 수")
+              )
+            ));
     }
 
     @Test
@@ -297,32 +294,32 @@ public class PostControllerTest extends RestDocsTestSupport {
             .content(createJson(request)))
           .andExpect(status().isOk())
           .andExpect(jsonPath("$.total").value(response.getTotal()))
-          .andDo(print())
-          .andDo(restDocs.document(
-            requestFields(
-              fieldWithPath("location[].city").description("도시 ID"),
-              fieldWithPath("location[].district").description("구 ID"),
-              fieldWithPath("seasonTagIds").description("계절 태그 ID 리스트"),
-              fieldWithPath("weatherTagIds").description("날씨 태그 ID 리스트"),
-              fieldWithPath("temperatureTagIds").description("온도 태그 ID 리스트"),
-              fieldWithPath("gender").description("성별 (FEMALE 또는 MALE)"),
-              fieldWithPath("sort").description("정렬 조건: LATEST, LIKED"),
-              fieldWithPath("page").description("페이지 번호 (0부터 시작)"),
-              fieldWithPath("size").description("페이지 크기")
-            ),
-            responseFields(
-              fieldWithPath("posts[].postId").description("게시글 ID"),
-              fieldWithPath("posts[].thumbnail").description("썸네일 이미지 URL"),
-              fieldWithPath("posts[].location.city").description("도시"),
-              fieldWithPath("posts[].location.district").description("구"),
-              fieldWithPath("posts[].seasonTag").description("계절 태그"),
-              fieldWithPath("posts[].weatherTags").description("날씨 태그 리스트"),
-              fieldWithPath("posts[].temperatureTags").description("온도 태그 리스트"),
-              fieldWithPath("posts[].likeByUser").description("사용자 좋아요 여부"),
-              fieldWithPath("posts[].gender").description("성별"),
-              fieldWithPath("total").description("총 페이지 수")
-            )
-          ));
+          .andDo(
+            restDocs.document(
+              requestFields(
+                fieldWithPath("location[].city").description("도시 ID"),
+                fieldWithPath("location[].district").description("구 ID"),
+                fieldWithPath("seasonTagIds").description("계절 태그 ID 리스트"),
+                fieldWithPath("weatherTagIds").description("날씨 태그 ID 리스트"),
+                fieldWithPath("temperatureTagIds").description("온도 태그 ID 리스트"),
+                fieldWithPath("gender").description("성별 (FEMALE 또는 MALE)"),
+                fieldWithPath("sort").description("정렬 조건: LATEST, LIKED"),
+                fieldWithPath("page").description("페이지 번호 (0부터 시작)"),
+                fieldWithPath("size").description("페이지 크기")
+              ),
+              responseFields(
+                fieldWithPath("posts[].postId").description("게시글 ID"),
+                fieldWithPath("posts[].thumbnail").description("썸네일 이미지 URL"),
+                fieldWithPath("posts[].location.city").description("도시"),
+                fieldWithPath("posts[].location.district").description("구"),
+                fieldWithPath("posts[].seasonTag").description("계절 태그"),
+                fieldWithPath("posts[].weatherTags").description("날씨 태그 리스트"),
+                fieldWithPath("posts[].temperatureTags").description("온도 태그 리스트"),
+                fieldWithPath("posts[].likeByUser").description("사용자 좋아요 여부"),
+                fieldWithPath("posts[].gender").description("성별"),
+                fieldWithPath("total").description("총 페이지 수")
+              )
+            ));
     }
 
     @Test
@@ -344,27 +341,27 @@ public class PostControllerTest extends RestDocsTestSupport {
             .param("page", String.valueOf(page))
             .param("size", String.valueOf(size)))
           .andExpect(status().isOk())
-          .andDo(print())
-          .andDo(restDocs.document(
-            queryParameters(
-              parameterWithName("tmp").description("현재 온도"),
-              parameterWithName("page").description("페이지 번호"),
-              parameterWithName("size").description("페이지 크기")
-            ),
-            responseFields(
-              fieldWithPath("tmpRangeStart").description("추천 온도 범위 시작"),
-              fieldWithPath("tmpRangeEnd").description("추천 온도 범위 끝"),
-              fieldWithPath("posts[].postId").description("게시글 ID"),
-              fieldWithPath("posts[].thumbnail").description("썸네일 이미지 URL"),
-              fieldWithPath("posts[].location.city").description("도시"),
-              fieldWithPath("posts[].location.district").description("구"),
-              fieldWithPath("posts[].seasonTag").description("계절 태그"),
-              fieldWithPath("posts[].weatherTags").description("날씨 태그 리스트"),
-              fieldWithPath("posts[].temperatureTags").description("온도 태그 리스트"),
-              fieldWithPath("posts[].likeByUser").description("사용자 좋아요 여부"),
-              fieldWithPath("total").description("총 페이지 수")
-            )
-          ));
+          .andDo(
+            restDocs.document(
+              queryParameters(
+                parameterWithName("tmp").description("현재 온도"),
+                parameterWithName("page").description("페이지 번호"),
+                parameterWithName("size").description("페이지 크기")
+              ),
+              responseFields(
+                fieldWithPath("tmpRangeStart").description("추천 온도 범위 시작"),
+                fieldWithPath("tmpRangeEnd").description("추천 온도 범위 끝"),
+                fieldWithPath("posts[].postId").description("게시글 ID"),
+                fieldWithPath("posts[].thumbnail").description("썸네일 이미지 URL"),
+                fieldWithPath("posts[].location.city").description("도시"),
+                fieldWithPath("posts[].location.district").description("구"),
+                fieldWithPath("posts[].seasonTag").description("계절 태그"),
+                fieldWithPath("posts[].weatherTags").description("날씨 태그 리스트"),
+                fieldWithPath("posts[].temperatureTags").description("온도 태그 리스트"),
+                fieldWithPath("posts[].likeByUser").description("사용자 좋아요 여부"),
+                fieldWithPath("total").description("총 페이지 수")
+              )
+            ));
     }
 
     @Test
@@ -384,24 +381,24 @@ public class PostControllerTest extends RestDocsTestSupport {
             .param("page", String.valueOf(page))
             .param("size", String.valueOf(size)))
           .andExpect(status().isOk())
-          .andDo(print())
-          .andDo(restDocs.document(
-            queryParameters(
-              parameterWithName("page").description("페이지 번호"),
-              parameterWithName("size").description("페이지 크기")
-            ),
-            responseFields(
-              fieldWithPath("myPosts[].postId").description("게시글 ID"),
-              fieldWithPath("myPosts[].thumbnail").description("썸네일 이미지 URL"),
-              fieldWithPath("myPosts[].location.city").description("도시"),
-              fieldWithPath("myPosts[].location.district").description("구"),
-              fieldWithPath("myPosts[].seasonTag").description("계절 태그"),
-              fieldWithPath("myPosts[].weatherTags").description("날씨 태그 리스트"),
-              fieldWithPath("myPosts[].temperatureTags").description("온도 태그 리스트"),
-              fieldWithPath("myPosts[].likeByUser").description("사용자 좋아요 여부"),
-              fieldWithPath("myPosts[].reportPost").description("신고 여부"),
-              fieldWithPath("total").description("총 페이지 수")
-            )
-          ));
+          .andDo(
+            restDocs.document(
+              queryParameters(
+                parameterWithName("page").description("페이지 번호"),
+                parameterWithName("size").description("페이지 크기")
+              ),
+              responseFields(
+                fieldWithPath("myPosts[].postId").description("게시글 ID"),
+                fieldWithPath("myPosts[].thumbnail").description("썸네일 이미지 URL"),
+                fieldWithPath("myPosts[].location.city").description("도시"),
+                fieldWithPath("myPosts[].location.district").description("구"),
+                fieldWithPath("myPosts[].seasonTag").description("계절 태그"),
+                fieldWithPath("myPosts[].weatherTags").description("날씨 태그 리스트"),
+                fieldWithPath("myPosts[].temperatureTags").description("온도 태그 리스트"),
+                fieldWithPath("myPosts[].likeByUser").description("사용자 좋아요 여부"),
+                fieldWithPath("myPosts[].reportPost").description("신고 여부"),
+                fieldWithPath("total").description("총 페이지 수")
+              )
+            ));
     }
 }

--- a/src/test/java/com/WearWeather/wear/domain/postHidden/controller/PostHiddenControllerTest.java
+++ b/src/test/java/com/WearWeather/wear/domain/postHidden/controller/PostHiddenControllerTest.java
@@ -26,13 +26,11 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.security.test.context.support.WithMockUser;
 
-@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
-@SuppressWarnings("NonAsciiCharacters")
+@WithMockUser
 @WebMvcTest(PostHiddenController.class)
-@Import(RestDocsConfig.class)
-@AutoConfigureMockMvc(addFilters = false)
-@MockBean(JpaMetamodelMappingContext.class)
+@AutoConfigureMockMvc
 class PostHiddenControllerTest extends RestDocsTestSupport {
 
     @MockBean
@@ -57,14 +55,15 @@ class PostHiddenControllerTest extends RestDocsTestSupport {
           .andExpect(header().string("Location", "/posts/" + postId + "/hide"))
           .andExpect(jsonPath("$.success").value(true))
           .andExpect(jsonPath("$.message").value(ResponseMessage.SUCCESS_POST_HIDDEN))
-          .andDo(restDocs.document(
-            pathParameters(
-              parameterWithName("postId").description("숨길 게시글 ID")
-            ),
-            responseFields(
-              fieldWithPath("success").description("요청 성공 여부"),
-              fieldWithPath("message").description("응답 메시지")
-            )
-          ));
+          .andDo(
+            restDocs.document(
+              pathParameters(
+                parameterWithName("postId").description("숨길 게시글 ID")
+              ),
+              responseFields(
+                fieldWithPath("success").description("요청 성공 여부"),
+                fieldWithPath("message").description("응답 메시지")
+              )
+            ));
     }
 }

--- a/src/test/java/com/WearWeather/wear/domain/postLike/controller/LikeControllerTest.java
+++ b/src/test/java/com/WearWeather/wear/domain/postLike/controller/LikeControllerTest.java
@@ -37,12 +37,11 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.security.test.context.support.WithMockUser;
 
-@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
-@SuppressWarnings("NonAsciiCharacters")
+@WithMockUser
 @WebMvcTest(LikeController.class)
-@AutoConfigureMockMvc(addFilters = false)
-@MockBean(JpaMetamodelMappingContext.class)
+@AutoConfigureMockMvc
 class LikeControllerTest extends RestDocsTestSupport {
 
     @MockBean
@@ -72,15 +71,15 @@ class LikeControllerTest extends RestDocsTestSupport {
         mockMvc.perform(post("/likes/posts/{postId}", 1L))
           .andExpect(status().isCreated())
           .andExpect(jsonPath("$.likedCount").value(10))
-          .andDo(print())
-          .andDo(restDocs.document(
-            pathParameters(
-              parameterWithName("postId").description("게시글 ID")
-            ),
-            responseFields(
-              fieldWithPath("likedCount").description("좋아요 수")
-            )
-          ));
+          .andDo(
+            restDocs.document(
+              pathParameters(
+                parameterWithName("postId").description("게시글 ID")
+              ),
+              responseFields(
+                fieldWithPath("likedCount").description("좋아요 수")
+              )
+            ));
     }
 
     @Test
@@ -92,15 +91,15 @@ class LikeControllerTest extends RestDocsTestSupport {
         mockMvc.perform(delete("/likes/posts/{postId}", 1L))
           .andExpect(status().isCreated())
           .andExpect(jsonPath("$.likedCount").value(7))
-          .andDo(print())
-          .andDo(restDocs.document(
-            pathParameters(
-              parameterWithName("postId").description("게시글 ID")
-            ),
-            responseFields(
-              fieldWithPath("likedCount").description("좋아요 수")
-            )
-          ));
+          .andDo(
+            restDocs.document(
+              pathParameters(
+                parameterWithName("postId").description("게시글 ID")
+              ),
+              responseFields(
+                fieldWithPath("likedCount").description("좋아요 수")
+              )
+            ));
     }
 
     @Test
@@ -130,23 +129,23 @@ class LikeControllerTest extends RestDocsTestSupport {
           .andExpect(jsonPath("$.myLikedPosts[0].postId").value(1L))
           .andExpect(jsonPath("$.myLikedPosts[0].seasonTag").value("봄"))
           .andExpect(jsonPath("$.total").value(1))
-          .andDo(print())
-          .andDo(restDocs.document(
-            queryParameters(
-              parameterWithName("page").description("페이지 번호"),
-              parameterWithName("size").description("페이지 크기")
-            ),
-            responseFields(
-              fieldWithPath("myLikedPosts[].postId").description("게시글 ID"),
-              fieldWithPath("myLikedPosts[].thumbnail").description("썸네일 이미지 URL"),
-              fieldWithPath("myLikedPosts[].location.city").description("도시 이름"),
-              fieldWithPath("myLikedPosts[].location.district").description("구 이름"),
-              fieldWithPath("myLikedPosts[].seasonTag").description("계절 태그"),
-              fieldWithPath("myLikedPosts[].weatherTags").description("날씨 태그 리스트"),
-              fieldWithPath("myLikedPosts[].temperatureTags").description("온도 태그 리스트"),
-              fieldWithPath("myLikedPosts[].likeByUser").description("유저가 좋아요했는지 여부"),
-              fieldWithPath("total").description("총 페이지 수")
-            )
-          ));
+          .andDo(
+            restDocs.document(
+              queryParameters(
+                parameterWithName("page").description("페이지 번호"),
+                parameterWithName("size").description("페이지 크기")
+              ),
+              responseFields(
+                fieldWithPath("myLikedPosts[].postId").description("게시글 ID"),
+                fieldWithPath("myLikedPosts[].thumbnail").description("썸네일 이미지 URL"),
+                fieldWithPath("myLikedPosts[].location.city").description("도시 이름"),
+                fieldWithPath("myLikedPosts[].location.district").description("구 이름"),
+                fieldWithPath("myLikedPosts[].seasonTag").description("계절 태그"),
+                fieldWithPath("myLikedPosts[].weatherTags").description("날씨 태그 리스트"),
+                fieldWithPath("myLikedPosts[].temperatureTags").description("온도 태그 리스트"),
+                fieldWithPath("myLikedPosts[].likeByUser").description("유저가 좋아요했는지 여부"),
+                fieldWithPath("total").description("총 페이지 수")
+              )
+            ));
     }
 }

--- a/src/test/java/com/WearWeather/wear/domain/postReport/controller/PostReportControllerTest.java
+++ b/src/test/java/com/WearWeather/wear/domain/postReport/controller/PostReportControllerTest.java
@@ -26,12 +26,11 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.security.test.context.support.WithMockUser;
 
-@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
-@SuppressWarnings("NonAsciiCharacters")
-@MockBean(JpaMetamodelMappingContext.class)
+@WithMockUser
 @WebMvcTest(PostReportController.class)
-@AutoConfigureMockMvc(addFilters = false)
+@AutoConfigureMockMvc
 class PostReportControllerTest extends RestDocsTestSupport {
 
     @MockBean
@@ -60,18 +59,18 @@ class PostReportControllerTest extends RestDocsTestSupport {
           .andExpect(header().string("Location", "/posts/" + postId + "/report"))
           .andExpect(jsonPath("$.success").value(true))
           .andExpect(jsonPath("$.message").value(ResponseMessage.SUCCESS_REPORT_POST))
-          .andDo(print())
-          .andDo(restDocs.document(
-            pathParameters(
-              parameterWithName("postId").description("신고할 게시글 ID")
-            ),
-            queryParameters(
-              parameterWithName("reason").description("신고 사유")
-            ),
-            responseFields(
-              fieldWithPath("success").description("요청 성공 여부"),
-              fieldWithPath("message").description("응답 메시지")
-            )
-          ));
+          .andDo(
+            restDocs.document(
+              pathParameters(
+                parameterWithName("postId").description("신고할 게시글 ID")
+              ),
+              queryParameters(
+                parameterWithName("reason").description("신고 사유")
+              ),
+              responseFields(
+                fieldWithPath("success").description("요청 성공 여부"),
+                fieldWithPath("message").description("응답 메시지")
+              )
+            ));
     }
 }

--- a/src/test/java/com/WearWeather/wear/domain/storage/controller/AwsS3ControllerTest.java
+++ b/src/test/java/com/WearWeather/wear/domain/storage/controller/AwsS3ControllerTest.java
@@ -30,12 +30,11 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.test.context.support.WithMockUser;
 
-@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
-@SuppressWarnings("NonAsciiCharacters")
-@MockBean(JpaMetamodelMappingContext.class)
+@WithMockUser
 @WebMvcTest(AwsS3Controller.class)
-@AutoConfigureMockMvc(addFilters = false)
+@AutoConfigureMockMvc
 class AwsS3ControllerTest extends RestDocsTestSupport {
 
     @MockBean
@@ -62,16 +61,16 @@ class AwsS3ControllerTest extends RestDocsTestSupport {
           .andExpect(status().isOk())
           .andExpect(jsonPath("$.id").value(1L))
           .andExpect(jsonPath("$.url").value("https://s3.bucket.com/image.jpg"))
-          .andDo(print())
-          .andDo(restDocs.document(
-            requestParts(
-              partWithName("file").description("업로드할 이미지 파일")
-            ),
-            responseFields(
-              fieldWithPath("id").description("업로드된 이미지 ID"),
-              fieldWithPath("url").description("S3 이미지 URL")
-            )
-          ));
+          .andDo(
+            restDocs.document(
+              requestParts(
+                partWithName("file").description("업로드할 이미지 파일")
+              ),
+              responseFields(
+                fieldWithPath("id").description("업로드된 이미지 ID"),
+                fieldWithPath("url").description("S3 이미지 URL")
+              )
+            ));
     }
 
     @Test
@@ -84,11 +83,11 @@ class AwsS3ControllerTest extends RestDocsTestSupport {
         // when & then
         mockMvc.perform(delete("/s3/post-image/{imageId}", imageId))
           .andExpect(status().isNoContent())
-          .andDo(print())
-          .andDo(restDocs.document(
-            pathParameters(
-              parameterWithName("imageId").description("삭제할 이미지 ID")
-            )
-          ));
+          .andDo(
+            restDocs.document(
+              pathParameters(
+                parameterWithName("imageId").description("삭제할 이미지 ID")
+              )
+            ));
     }
 }

--- a/src/test/java/com/WearWeather/wear/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/WearWeather/wear/domain/user/controller/UserControllerTest.java
@@ -29,21 +29,17 @@ import com.WearWeather.wear.global.common.ResponseMessage;
 import com.WearWeather.wear.global.jwt.UserIdArgumentResolver;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.DisplayNameGeneration;
-import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 import org.mockito.BDDMockito;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
 
-@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
-@SuppressWarnings("NonAsciiCharacters")
-@MockBean(JpaMetamodelMappingContext.class)
+@WithMockUser
 @WebMvcTest(UserController.class)
-@AutoConfigureMockMvc(addFilters = false)
+@AutoConfigureMockMvc
 class UserControllerTest extends RestDocsTestSupport {
 
     @MockBean
@@ -72,20 +68,21 @@ class UserControllerTest extends RestDocsTestSupport {
           .andExpect(status().isOk())
           .andExpect(jsonPath("$.success").value(true))
           .andExpect(jsonPath("$.message").value(ResponseMessage.SUCCESS_USER))
-          .andDo(restDocs.document(
-            requestFields(
-              fieldWithPath("email").description("이메일"),
-              fieldWithPath("password").description("비밀번호"),
-              fieldWithPath("name").description("이름"),
-              fieldWithPath("nickname").description("닉네임"),
-              fieldWithPath("social").description("소셜 로그인 여부") // 여기!
-            )
-            ,
-            responseFields(
-              fieldWithPath("success").description("요청 성공 여부"),
-              fieldWithPath("message").description("응답 메시지")
-            )
-          ));
+          .andDo(
+            restDocs.document(
+              requestFields(
+                fieldWithPath("email").description("이메일"),
+                fieldWithPath("password").description("비밀번호"),
+                fieldWithPath("name").description("이름"),
+                fieldWithPath("nickname").description("닉네임"),
+                fieldWithPath("social").description("소셜 로그인 여부") // 여기!
+              )
+              ,
+              responseFields(
+                fieldWithPath("success").description("요청 성공 여부"),
+                fieldWithPath("message").description("응답 메시지")
+              )
+            ));
     }
 
     @Test
@@ -98,15 +95,16 @@ class UserControllerTest extends RestDocsTestSupport {
           .andExpect(status().isOk())
           .andExpect(jsonPath("$.available").value(true)) // <-- 수정
           .andExpect(jsonPath("$.message").value(ResponseMessage.NICKNAME_AVAILABLE))
-          .andDo(restDocs.document(
-            pathParameters(
-              parameterWithName("nickname").description("중복 확인할 닉네임")
-            ),
-            responseFields(
-              fieldWithPath("available").description("사용 가능 여부"), // <-- 수정
-              fieldWithPath("message").description("응답 메시지")
-            )
-          ));
+          .andDo(
+            restDocs.document(
+              pathParameters(
+                parameterWithName("nickname").description("중복 확인할 닉네임")
+              ),
+              responseFields(
+                fieldWithPath("available").description("사용 가능 여부"), // <-- 수정
+                fieldWithPath("message").description("응답 메시지")
+              )
+            ));
     }
 
     @Test
@@ -120,15 +118,16 @@ class UserControllerTest extends RestDocsTestSupport {
             .content(createJson(request)))
           .andExpect(status().isOk())
           .andExpect(jsonPath("$.email").value("test@email.com"))
-          .andDo(restDocs.document(
-            requestFields(
-              fieldWithPath("name").description("사용자 이름"),
-              fieldWithPath("nickname").description("사용자 닉네임")
-            ),
-            responseFields(
-              fieldWithPath("email").description("조회된 사용자 이메일")
-            )
-          ));
+          .andDo(
+            restDocs.document(
+              requestFields(
+                fieldWithPath("name").description("사용자 이름"),
+                fieldWithPath("nickname").description("사용자 닉네임")
+              ),
+              responseFields(
+                fieldWithPath("email").description("조회된 사용자 이메일")
+              )
+            ));
     }
 
     @Test
@@ -142,16 +141,17 @@ class UserControllerTest extends RestDocsTestSupport {
             .content(createJson(request)))
           .andExpect(status().isOk())
           .andExpect(jsonPath("$.userId").value(1L))
-          .andDo(restDocs.document(
-            requestFields(
-              fieldWithPath("email").description("사용자 이메일"),
-              fieldWithPath("name").description("사용자 이름"),
-              fieldWithPath("nickname").description("사용자 닉네임")
-            ),
-            responseFields(
-              fieldWithPath("userId").description("조회된 사용자 ID")
-            )
-          ));
+          .andDo(
+            restDocs.document(
+              requestFields(
+                fieldWithPath("email").description("사용자 이메일"),
+                fieldWithPath("name").description("사용자 이름"),
+                fieldWithPath("nickname").description("사용자 닉네임")
+              ),
+              responseFields(
+                fieldWithPath("userId").description("조회된 사용자 ID")
+              )
+            ));
     }
 
     @Test
@@ -165,16 +165,17 @@ class UserControllerTest extends RestDocsTestSupport {
           .andExpect(status().isOk())
           .andExpect(jsonPath("$.success").value(true))
           .andExpect(jsonPath("$.message").value(ResponseMessage.MODIFY_PASSWORD))
-          .andDo(restDocs.document(
-            requestFields(
-              fieldWithPath("userId").description("회원 ID"),
-              fieldWithPath("password").description("변경할 비밀번호")
-            ),
-            responseFields(
-              fieldWithPath("success").description("요청 성공 여부"),
-              fieldWithPath("message").description("응답 메시지")
-            )
-          ));
+          .andDo(
+            restDocs.document(
+              requestFields(
+                fieldWithPath("userId").description("회원 ID"),
+                fieldWithPath("password").description("변경할 비밀번호")
+              ),
+              responseFields(
+                fieldWithPath("success").description("요청 성공 여부"),
+                fieldWithPath("message").description("응답 메시지")
+              )
+            ));
     }
 
     @Test
@@ -189,14 +190,15 @@ class UserControllerTest extends RestDocsTestSupport {
           .andExpect(jsonPath("$.name").value("홍길동"))
           .andExpect(jsonPath("$.nickname").value("길동이"))
           .andExpect(jsonPath("$.social").value(false))
-          .andDo(restDocs.document(
-            responseFields(
-              fieldWithPath("email").description("이메일"),
-              fieldWithPath("name").description("이름"),
-              fieldWithPath("nickname").description("닉네임"),
-              fieldWithPath("social").description("소셜 로그인 여부")
-            )
-          ));
+          .andDo(
+            restDocs.document(
+              responseFields(
+                fieldWithPath("email").description("이메일"),
+                fieldWithPath("name").description("이름"),
+                fieldWithPath("nickname").description("닉네임"),
+                fieldWithPath("social").description("소셜 로그인 여부")
+              )
+            ));
     }
 
     @Test
@@ -210,16 +212,17 @@ class UserControllerTest extends RestDocsTestSupport {
           .andExpect(status().isOk())
           .andExpect(jsonPath("$.success").value(true))
           .andExpect(jsonPath("$.message").value(ResponseMessage.MODIFY_USERINFO))
-          .andDo(restDocs.document(
-            requestFields(
-              fieldWithPath("password").description("비밀번호"),
-              fieldWithPath("nickname").description("변경할 닉네임")
-            ),
-            responseFields(
-              fieldWithPath("success").description("요청 성공 여부"),
-              fieldWithPath("message").description("응답 메시지")
-            )
-          ));
+          .andDo(
+            restDocs.document(
+              requestFields(
+                fieldWithPath("password").description("비밀번호"),
+                fieldWithPath("nickname").description("변경할 닉네임")
+              ),
+              responseFields(
+                fieldWithPath("success").description("요청 성공 여부"),
+                fieldWithPath("message").description("응답 메시지")
+              )
+            ));
     }
 
     @Test
@@ -232,14 +235,15 @@ class UserControllerTest extends RestDocsTestSupport {
           .andExpect(status().isOk())
           .andExpect(jsonPath("$.success").value(true))
           .andExpect(jsonPath("$.message").value(ResponseMessage.SUCCESS_DELETE_USER))
-          .andDo(restDocs.document(
-            queryParameters(
-              parameterWithName("deleteReason").description("회원 탈퇴 사유")
-            ),
-            responseFields(
-              fieldWithPath("success").description("요청 성공 여부"),
-              fieldWithPath("message").description("응답 메시지")
-            )
-          ));
+          .andDo(
+            restDocs.document(
+              queryParameters(
+                parameterWithName("deleteReason").description("회원 탈퇴 사유")
+              ),
+              responseFields(
+                fieldWithPath("success").description("요청 성공 여부"),
+                fieldWithPath("message").description("응답 메시지")
+              )
+            ));
     }
 }

--- a/src/test/java/com/WearWeather/wear/domain/user/controller/UserDeleteControllerTest.java
+++ b/src/test/java/com/WearWeather/wear/domain/user/controller/UserDeleteControllerTest.java
@@ -11,19 +11,15 @@ import com.WearWeather.wear.domain.user.facade.UserDeleteFacade;
 import com.WearWeather.wear.domain.user.service.UserService;
 import com.WearWeather.wear.global.jwt.UserIdArgumentResolver;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.DisplayNameGeneration;
-import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.security.test.context.support.WithMockUser;
 
-@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
-@SuppressWarnings("NonAsciiCharacters")
-@MockBean(JpaMetamodelMappingContext.class)
+@WithMockUser
 @WebMvcTest(UserDeleteController.class)
-@AutoConfigureMockMvc(addFilters = false)
+@AutoConfigureMockMvc
 class UserDeleteControllerTest extends RestDocsTestSupport {
 
     @MockBean
@@ -45,10 +41,11 @@ class UserDeleteControllerTest extends RestDocsTestSupport {
           .andExpect(jsonPath("$[2]").value("개인정보 보호를 위해 삭제할 필요가 있어요"))
           .andExpect(jsonPath("$[3]").value("서비스 기능이 미흡해요"))
           .andExpect(jsonPath("$[4]").value("오류가 잦아요"))
-          .andDo(restDocs.document(
-            responseFields(
-              fieldWithPath("[].").description("회원 탈퇴 사유 목록")
-            )
-          ));
+          .andDo(
+            restDocs.document(
+              responseFields(
+                fieldWithPath("[].").description("회원 탈퇴 사유 목록")
+              )
+            ));
     }
 }

--- a/src/test/java/com/WearWeather/wear/domain/weather/controller/WeatherControllerTest.java
+++ b/src/test/java/com/WearWeather/wear/domain/weather/controller/WeatherControllerTest.java
@@ -16,19 +16,15 @@ import com.WearWeather.wear.domain.weather.dto.response.WeatherTmpResponse;
 import com.WearWeather.wear.domain.weather.service.WeatherService;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.DisplayNameGeneration;
-import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.security.test.context.support.WithMockUser;
 
-@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
-@SuppressWarnings("NonAsciiCharacters")
-@MockBean(JpaMetamodelMappingContext.class)
+@WithMockUser
 @WebMvcTest(WeatherController.class)
-@AutoConfigureMockMvc(addFilters = false)
+@AutoConfigureMockMvc
 class WeatherControllerTest extends RestDocsTestSupport {
 
     @MockBean
@@ -52,17 +48,18 @@ class WeatherControllerTest extends RestDocsTestSupport {
           .andExpect(jsonPath("$.currentTemp").value("24.0"))
           .andExpect(jsonPath("$.weatherType").value("맑음"))
           .andExpect(jsonPath("$.weatherMessage").value("선선한 날씨입니다."))
-          .andDo(restDocs.document(
-            queryParameters(
-              parameterWithName("longitude").description("경도"),
-              parameterWithName("latitude").description("위도")
-            ),
-            responseFields(
-              fieldWithPath("currentTemp").description("현재 기온"),
-              fieldWithPath("weatherType").description("날씨 유형"),
-              fieldWithPath("weatherMessage").description("날씨 메시지")
-            )
-          ));
+          .andDo(
+            restDocs.document(
+              queryParameters(
+                parameterWithName("longitude").description("경도"),
+                parameterWithName("latitude").description("위도")
+              ),
+              responseFields(
+                fieldWithPath("currentTemp").description("현재 기온"),
+                fieldWithPath("weatherType").description("날씨 유형"),
+                fieldWithPath("weatherMessage").description("날씨 메시지")
+              )
+            ));
     }
 
     @Test
@@ -82,16 +79,17 @@ class WeatherControllerTest extends RestDocsTestSupport {
           .andExpect(status().isOk())
           .andExpect(jsonPath("$.minTemp").value("18.0"))
           .andExpect(jsonPath("$.maxTemp").value("27.0"))
-          .andDo(restDocs.document(
-            queryParameters(
-              parameterWithName("longitude").description("경도"),
-              parameterWithName("latitude").description("위도")
-            ),
-            responseFields(
-              fieldWithPath("minTemp").description("최저 기온"),
-              fieldWithPath("maxTemp").description("최고 기온")
-            )
-          ));
+          .andDo(
+            restDocs.document(
+              queryParameters(
+                parameterWithName("longitude").description("경도"),
+                parameterWithName("latitude").description("위도")
+              ),
+              responseFields(
+                fieldWithPath("minTemp").description("최저 기온"),
+                fieldWithPath("maxTemp").description("최고 기온")
+              )
+            ));
     }
 
     @Test
@@ -116,16 +114,17 @@ class WeatherControllerTest extends RestDocsTestSupport {
           .andExpect(jsonPath("$.categorySentence").value("가벼운 겉옷이 필요해요."))
           .andExpect(jsonPath("$.outfit").value("얇은 니트와 청바지"))
           .andExpect(jsonPath("$.outfitImages").isArray())
-          .andDo(restDocs.document(
-            queryParameters(
-              parameterWithName("tmp").description("현재 기온")
-            ),
-            responseFields(
-              fieldWithPath("category").description("카테고리"),
-              fieldWithPath("categorySentence").description("추천 문구"),
-              fieldWithPath("outfit").description("추천 옷차림"),
-              fieldWithPath("outfitImages").description("추천 옷차림 이미지 리스트")
-            )
-          ));
+          .andDo(
+            restDocs.document(
+              queryParameters(
+                parameterWithName("tmp").description("현재 기온")
+              ),
+              responseFields(
+                fieldWithPath("category").description("카테고리"),
+                fieldWithPath("categorySentence").description("추천 문구"),
+                fieldWithPath("outfit").description("추천 옷차림"),
+                fieldWithPath("outfitImages").description("추천 옷차림 이미지 리스트")
+              )
+            ));
     }
 }


### PR DESCRIPTION
## 🚩 연관 이슈
close #131 

## 🗣️ 작업 개요
- Spring REST Docs 테스트 코드 내 사용되지 않는 어노테이션 및 중복 코드 정리

## 📝 작업 내용
- 한글 메서드명을 영어로 작성하면서 불필요해진 어노테이션 제거
  - `@DisplayNameGeneration`, `@SuppressWarnings("NonAsciiCharacters")`
- RestDocs 설정 커스터마이징으로 중복된 코드 제거
  - 예: 테스트마다 반복되던 `.with(csrf())`, `.andDo(print())` 제거
